### PR TITLE
Auto-assign reviewers to PRs

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,26 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: false
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - fpetkovski
+  - simonpasquier
+  - jan--f
+  - bison
+  - raptorsun
+  - prashbnair
+  - sthaha
+  - PhilipGough
+  - slashpai
+  - arajkumar
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it
+skipKeywords:
+  - wip
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 2

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,10 @@
 * @fpetkovski
+* @simonpasquier
+* @jan--f
+* @bison
+* @raptorsun
+* @prashbnair
+* @sthaha
+* @PhilipGough
+* @slashpai
+* @arajkumar


### PR DESCRIPTION
This commit configures the Github auto-assign app[1] to automatically
assign reviewers to pull requests.
[1] https://github.com/apps/auto-assign
