### PR TITLE
Simplify Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,41 +1,61 @@
 SHELL=/usr/bin/env bash -o pipefail
 
 IMAGE = monitoring-stack-operator
-VERSION?=$(shell cat VERSION)
+VERSION ?= $(shell cat VERSION)
 
-TOOLS_BIN_DIR=$(shell pwd)/tmp/bin
-export PATH := $(TOOLS_BIN_DIR):$(PATH)
-export GOBIN := $(TOOLS_BIN_DIR)
+# running make builds the operator (default target)
+all: operator
 
-TOOLS=\
-	$(TOOLS_BIN_DIR)/controller-gen \
-	$(TOOLS_BIN_DIR)/golangci-lint
 
-$(TOOLS_BIN_DIR):
-	mkdir -p $(TOOLS_BIN_DIR)
+## Tools
 
-$(TOOLS): $(TOOLS_BIN_DIR)
-	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
+TOOLS_DIR = $(shell pwd)/tmp/bin
+CONTROLLER_GEN=$(TOOLS_DIR)/controller-gen
+GOLANGCI_LINT=$(TOOLS_DIR)/golangci-lint
+
+$(TOOLS_DIR):
+	@mkdir -p $(TOOLS_DIR)
+
+$(CONTROLLER_GEN): $(TOOLS_DIR)
+	@{ \
+		set -e ;\
+		GOBIN=$(TOOLS_DIR) go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0 ;\
+	}
+
+$(GOLANGCI_LINT): $(TOOLS_DIR)
+	@{ \
+		set -e ;\
+		GOBIN=$(TOOLS_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1 ;\
+	}
+
+
+
+# Install all required tools
+tools: $(CONTROLLER_GEN) $(GOLANGCI_LINT) ##
+
+## Development
 
 .PHONY: lint
-lint: $(TOOLS)
-	golangci-lint run ./... --fix
+lint: $(GOLANGCI_LINT)
+	$(GOLANGCI_LINT) run ./... --fix
 
 .PHONY: generate-crds
-generate-crds: $(TOOLS)
-	controller-gen \
-		crd paths=./pkg/apis/... \
+generate-crds: $(CONTROLLER_GEN)
+	$(CONTROLLER_GEN) crd \
+		paths=./pkg/apis/... \
 		rbac:roleName=monitoring \
 		output:dir=./deploy \
 		output:crd:dir=./deploy/crds
 
 .PHONY: generate-deepcopy
-generate-deepcopy: $(TOOLS)
-	controller-gen object paths=./pkg/apis/...
+generate-deepcopy: $(CONTROLLER_GEN)
+	$(CONTROLLER_GEN) object paths=./pkg/apis/...
 
 .PHONY: generate
 generate: generate-crds generate-deepcopy
+
+operator: generate
+	go build -o ./tmp/operator ./cmd/operator/...
 
 .PHONY: image
 image:


### PR DESCRIPTION
* Removes need for modifying env vars GOBIN and PATH for all targets.
* Adds `tools` target that install all tools only if they aren't
  installed (faster installs)
* Adds `operator` target that builds operator
* Running `make` builds the operator by default

Signed-off-by: Sunil Thaha <sthaha@redhat.com>