### PR TITLE
chore: update operator version after initiating a release

### DIFF
--- a/.versionrc
+++ b/.versionrc
@@ -7,5 +7,8 @@
       "filename": "VERSION",
       "type": "plain-text"
     }
-  ]
+  ],
+  "scripts": {
+    "postbump": "make generate"
+  }
 }

--- a/Makefile
+++ b/Makefile
@@ -91,12 +91,17 @@ generate-crds: $(CONTROLLER_GEN)
 		output:rbac:dir=./deploy/operator \
 		output:crd:dir=./deploy/crds
 
+.PHONY: generate-kustomize
+generate-kustomize: $(KUSTOMIZE)
+	cd deploy/operator && \
+		$(KUSTOMIZE) edit set image monitoring-stack-operator=*:$(VERSION)
+
 .PHONY: generate-deepcopy
 generate-deepcopy: $(CONTROLLER_GEN)
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./pkg/apis/..."
 
 .PHONY: generate
-generate: generate-crds generate-deepcopy
+generate: generate-crds generate-deepcopy generate-kustomize
 
 operator: generate
 	go build -o ./tmp/operator ./cmd/operator/...

--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ For detailed information on the available code generation markers, please refer 
 ### Running the operator in kind
 * Install [kind](https://github.com/kubernetes-sigs/kind)
 * Create a local kubernetes cluster with `kind create cluster`.
-* Build the operator image with `make operator-image`.
-* Load the image into your cluster with `kind load docker-image monitoring-stack-operator:$(cat VERSION)`
 * Apply the CRDs by running `kubectl apply -k deploy/crds/`
 * Set the `KUBECONFIG` environment variable to your local cluster and run the with `go run cmd/operator/main.go`.
   * Alternatively, you can also set the kubeconfig on the command line: `go run cmd/operator/main.go --kubeconfig <path-to-kubeconfig>`

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ For detailed information on the available code generation markers, please refer 
 ### Running the operator in kind
 * Install [kind](https://github.com/kubernetes-sigs/kind)
 * Create a local kubernetes cluster with `kind create cluster`.
+* Build the operator image with `make operator-image`.
+* Load the image into your cluster with `kind load docker-image monitoring-stack-operator:$(cat VERSION)`
 * Apply the CRDs by running `kubectl apply -k deploy/crds/`
 * Set the `KUBECONFIG` environment variable to your local cluster and run the with `go run cmd/operator/main.go`.
   * Alternatively, you can also set the kubeconfig on the command line: `go run cmd/operator/main.go --kubeconfig <path-to-kubeconfig>`

--- a/deploy/olm/kustomization.yaml
+++ b/deploy/olm/kustomization.yaml
@@ -9,7 +9,6 @@ kind: Kustomization
 images:
   - name: monitoring-stack-operator
     newName: quay.io/sthaha/monitoring-stack-operator
-    newTag: 0.0.1
 
 patches:
 - patch: |-

--- a/deploy/operator/kustomization.yaml
+++ b/deploy/operator/kustomization.yaml
@@ -5,3 +5,8 @@ resources:
 - role.yaml
 - serviceaccount.yaml
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: monitoring-stack-operator
+  newTag: 0.0.2


### PR DESCRIPTION
This commit adds a script which runs after the version is bumped. The
script sets the operator image tag to match the one specified in the
VERSION file.
