### PR TITLE
test: run operators in dedicated namespace

### DIFF
--- a/.github/e2e-tests/action.yaml
+++ b/.github/e2e-tests/action.yaml
@@ -49,7 +49,10 @@ runs:
       shell: bash
       run: |
         kubectl apply -k deploy/crds
-        kubectl apply -k deploy/operator
+        cd deploy/operator
+        kustomize edit set namespace operators
+        kubectl create ns operators
+        kubectl apply -k .
 
     - name: Wait for CRDs to become ready
       shell: bash


### PR DESCRIPTION
During the e2e run, the operators run in the default namespace. This
makes it harder to do a cleanup after the test is finished. It also does
not test cases when operators are installed in the non-default namespace
which is a more realistic scenarion.

This commit changes the operators' namespace to 'operators'.