### PR TITLE
feat: deploy a default grafana instance

### DIFF
--- a/deploy/operator/monitoring-stack-operator-cluster-role.yaml
+++ b/deploy/operator/monitoring-stack-operator-cluster-role.yaml
@@ -119,6 +119,16 @@ rules:
   - update
   - watch
 - apiGroups:
+  - integreatly.org
+  resources:
+  - grafanas
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - operators.coreos.com
   resources:
   - operatorgroups

--- a/pkg/eventsource/ticker.go
+++ b/pkg/eventsource/ticker.go
@@ -21,13 +21,13 @@ type TickerSource struct {
 }
 
 // NewTickerSource creates a new TickerSource
-func NewTickerSource() *TickerSource {
+func NewTickerSource(interval time.Duration) *TickerSource {
 	channel := make(chan event.GenericEvent, 1)
 	return &TickerSource{
 		Channel: source.Channel{
 			Source: channel,
 		},
-		ticker:  time.NewTicker(30 * time.Second),
+		ticker:  time.NewTicker(interval),
 		channel: channel,
 	}
 }

--- a/test/e2e/grafana_operator_test.go
+++ b/test/e2e/grafana_operator_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/grafana-operator/grafana-operator/v4/api/integreatly/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -69,26 +68,8 @@ func TestControllerRestoresDeletedResources(t *testing.T) {
 	}
 }
 
-func TestGrafanaOperatorForResourcesInOwnNamespace(t *testing.T) {
-	resources := []client.Object{
-		newGrafana(operatorNamespace),
-	}
-	defer deleteResources(resources...)
-
+func TestDefaultGrafanaInstanceIsCreated(t *testing.T) {
 	ts := []testCase{
-		{
-			name: "Operator should create Grafana Operator CRDs",
-			scenario: func(t *testing.T) {
-				f.AssertResourceEventuallyExists("grafanadashboards.integreatly.org", "", &apiextensionsv1.CustomResourceDefinition{})(t)
-				f.AssertResourceEventuallyExists("grafanadatasources.integreatly.org", "", &apiextensionsv1.CustomResourceDefinition{})(t)
-				f.AssertResourceEventuallyExists("grafananotificationchannels.integreatly.org", "", &apiextensionsv1.CustomResourceDefinition{})(t)
-				f.AssertResourceEventuallyExists("grafanas.integreatly.org", "", &apiextensionsv1.CustomResourceDefinition{})(t)
-			},
-		},
-		{
-			name:     "Create grafana operator resources",
-			scenario: createResources(resources...),
-		},
 		{
 			name: "Operator should reconcile resources in its own namespace",
 			scenario: func(t *testing.T) {


### PR DESCRIPTION
This commit deploys a default Grafana instance in the
monitoring-stack-operator namespace. The instance is configured to
collect all dashboards with the label: `app.kubernetes.io/part-of: monitoring-stack-operator`.