### PR TITLE
chore: enable audit logs in local kind cluster

### DIFF
--- a/hack/kind/audit-policy.yaml
+++ b/hack/kind/audit-policy.yaml
@@ -1,0 +1,4 @@
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+  - level: Metadata

--- a/hack/kind/config.yaml
+++ b/hack/kind/config.yaml
@@ -5,3 +5,30 @@ containerdConfigPatches:
   - |-
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."local-registry:5000"]
       endpoint = ["http://10.96.223.192:5000"]
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: ClusterConfiguration
+        apiServer:
+          # enable auditing flags on the API server
+          extraArgs:
+            audit-log-path: /var/log/kubernetes/kube-apiserver-audit.log
+            audit-policy-file: /etc/kubernetes/policies/audit-policy.yaml
+          # mount new files / directories on the control plane
+          extraVolumes:
+            - name: audit-policies
+              hostPath: /etc/kubernetes/policies
+              mountPath: /etc/kubernetes/policies
+              readOnly: true
+              pathType: "DirectoryOrCreate"
+            - name: "audit-logs"
+              hostPath: "/var/log/kubernetes"
+              mountPath: "/var/log/kubernetes"
+              readOnly: false
+              pathType: DirectoryOrCreate
+    # mount the local file on the control plane
+    extraMounts:
+      - hostPath: ./hack/kind/audit-policy.yaml
+        containerPath: /etc/kubernetes/policies/audit-policy.yaml
+        readOnly: true


### PR DESCRIPTION
This commit enables kube-apiserver audit logs in a local KinD cluster
for easier debugging and troubleshooting.