### PR TITLE
chore: remove the need for port-forwarding to the local registry

### DIFF
--- a/.github/e2e-tests-olm/action.yaml
+++ b/.github/e2e-tests-olm/action.yaml
@@ -43,11 +43,10 @@ runs:
         kubectl apply -f hack/kind/registry.yaml -n operators
         kubectl rollout status deployment local-registry -n operators
         # Expose the registry to the host so that we can build and push the image
-        kubectl port-forward -n operators svc/local-registry 5000:5000 &
         echo "127.0.0.1 local-registry" | sudo tee -a /etc/hosts
 
     - name: Build images
-      run: make operator-image bundle bundle-image IMAGE_BASE="local-registry:5000/monitoring-stack-operator" VERSION=0.0.0-ci
+      run: make operator-image bundle bundle-image IMAGE_BASE="local-registry:30000/monitoring-stack-operator" VERSION=0.0.0-ci
       shell: bash
 
     - name: Wait for cluster to finish bootstraping
@@ -58,7 +57,7 @@ runs:
         kubectl get pods -A
 
     - name: Publish images
-      run: make operator-push bundle-push IMAGE_BASE="local-registry:5000/monitoring-stack-operator" VERSION=0.0.0-ci
+      run: make operator-push bundle-push IMAGE_BASE="local-registry:30000/monitoring-stack-operator" VERSION=0.0.0-ci
       shell: bash
 
     - name: Deploy the operator
@@ -69,7 +68,7 @@ runs:
         kubectl wait --for=condition=Established crds --all --timeout=300s
 
         ./tmp/bin/operator-sdk run bundle \
-          local-registry:5000/monitoring-stack-operator-bundle:0.0.0-ci \
+          local-registry:30000/monitoring-stack-operator-bundle:0.0.0-ci \
           --install-mode AllNamespaces \
           --namespace operators \
           --skip-tls

--- a/hack/kind/config.yaml
+++ b/hack/kind/config.yaml
@@ -3,10 +3,13 @@ apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches:
   # 10.96.223.192 is the fixed ip of the registry service - see: hack/kind/registry.yaml
   - |-
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."local-registry:5000"]
-      endpoint = ["http://10.96.223.192:5000"]
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."local-registry:30000"]
+      endpoint = ["http://10.96.223.192:30000"]
 nodes:
   - role: control-plane
+    extraPortMappings:
+      - containerPort: 30000
+        hostPort: 30000
     kubeadmConfigPatches:
       - |
         kind: ClusterConfiguration

--- a/hack/kind/registry.yaml
+++ b/hack/kind/registry.yaml
@@ -23,16 +23,32 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: local-registry
   labels:
     app: local-registry
-  name: local-registry
 spec:
   # Use a fixed IP address so that we can use it in config.yaml to
   # patch the registry address and force an http protocol
   clusterIP: 10.96.223.192
   ports:
-    - port: 5000
+    - port: 30000
       protocol: TCP
       targetPort: 5000
+  selector:
+    app: local-registry
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: local-registry-node-port
+  labels:
+    app: local-registry
+spec:
+  type: NodePort
+  ports:
+    - protocol: TCP
+      port: 30000
+      targetPort: 5000
+      nodePort: 30000
   selector:
     app: local-registry


### PR DESCRIPTION
This commit exposes the local docker registry on NodePort 30000 and
removes the need to use port-forward from the host.