### PR TITLE
perf: fine-tune grafana-operator permissions

### DIFF
--- a/deploy/operator/monitoring-stack-operator-cluster-role.yaml
+++ b/deploy/operator/monitoring-stack-operator-cluster-role.yaml
@@ -22,7 +22,6 @@ rules:
   - namespaces
   verbs:
   - create
-  - list
 - apiGroups:
   - ""
   resourceNames:
@@ -30,7 +29,7 @@ rules:
   resources:
   - namespaces
   verbs:
-  - get
+  - list
   - watch
 - apiGroups:
   - ""
@@ -124,7 +123,6 @@ rules:
   - grafanas
   verbs:
   - create
-  - get
   - list
   - update
   - watch
@@ -135,8 +133,6 @@ rules:
   - subscriptions
   verbs:
   - create
-  - get
   - list
-  - patch
   - update
   - watch

--- a/pkg/controllers/grafana-operator/controller.go
+++ b/pkg/controllers/grafana-operator/controller.go
@@ -68,10 +68,10 @@ type reconciler struct {
 	grafanaClientset rest.Interface
 }
 
-//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;watch,resourceNames=monitoring-stack-operator
-//+kubebuilder:rbac:groups="",resources=namespaces,verbs=list;create
-//+kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions;operatorgroups,verbs=get;list;watch;create;update;patch,namespace=monitoring-stack-operator
-//+kubebuilder:rbac:groups=integreatly.org,namespace=monitoring-stack-operator,resources=grafanas,verbs=get;list;watch;create;update
+//+kubebuilder:rbac:groups="",resources=namespaces,verbs=list;watch,resourceNames=monitoring-stack-operator
+//+kubebuilder:rbac:groups="",resources=namespaces,verbs=create
+//+kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions;operatorgroups,verbs=list;watch;create;update,namespace=monitoring-stack-operator
+//+kubebuilder:rbac:groups=integreatly.org,namespace=monitoring-stack-operator,resources=grafanas,verbs=list;watch;create;update
 
 // RegisterWithManager registers the controller with Manager
 func RegisterWithManager(mgr controllerruntime.Manager) error {


### PR DESCRIPTION
This commit adjusts the grafana-operator controller permissions and
removes `get` permissions for all the resources which the controller
needs to watch.