### PR TITLE
ci: extract go version in a central place

### DIFF
--- a/.github/e2e-tests-olm/action.yaml
+++ b/.github/e2e-tests-olm/action.yaml
@@ -3,8 +3,7 @@ description: Runs E2E tests against the OLM bundle
 inputs:
   go-version:
     description: "go version"
-    required: false
-    default: 1.16
+    required: true
   kind-version:
     description: "kind version"
     required: false
@@ -19,7 +18,7 @@ runs:
   steps:
     - uses: actions/setup-go@v2.1.4
       with:
-        go-version: 1.16
+        go-version: ${{ inputs.go-version }}
 
     - uses: azure/setup-kubectl@v1
 

--- a/.github/env
+++ b/.github/env
@@ -1,0 +1,1 @@
+go-version=1.17

--- a/.github/olm-publish/action.yaml
+++ b/.github/olm-publish/action.yaml
@@ -7,6 +7,9 @@ inputs:
   quay_token:
     description: "Quay token"
     required: true
+  go-version:
+    description: "go version"
+    required: true
 runs:
   using: composite
   steps:
@@ -15,7 +18,7 @@ runs:
   - name: Setup Go environment
     uses: actions/setup-go@v2.1.4
     with:
-      go-version: 1.16
+      go-version: ${{ inputs.go-version }}
 
   - name: Registry Login
     uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9

--- a/.github/workflows/olm-candidate.yaml
+++ b/.github/workflows/olm-candidate.yaml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Import common environment variables
+        run: cat ".github/env" >> $GITHUB_ENV
+
       - name: Set version
         id: version
         run: |
@@ -29,3 +32,4 @@ jobs:
         with:
           quay_login: ${{ secrets.QUAY_LOGIN }}
           quay_token: ${{ secrets.QUAY_TOKEN }}
+          go-version: ${{ env.go-version }}

--- a/.github/workflows/olm-stable.yaml
+++ b/.github/workflows/olm-stable.yaml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Import common environment variables
+        run: cat ".github/env" >> $GITHUB_ENV
+
       - name: publish
         uses: ./.github/olm-publish
         env:
@@ -22,3 +25,4 @@ jobs:
         with:
           quay_login: ${{ secrets.QUAY_LOGIN }}
           quay_token: ${{ secrets.QUAY_TOKEN }}
+          go-version: ${{ env.go-version }}

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -2,9 +2,6 @@ name: checks
 on:
   pull_request:
 
-env:
-  go-version: '1.17'
-
 jobs:
   commit-lint:
     runs-on: ubuntu-latest
@@ -19,11 +16,16 @@ jobs:
     name: Golang linter
     steps:
       - uses: actions/checkout@v2
+
+      - name: Import common environment variables
+        run: cat ".github/env" >> $GITHUB_ENV
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.42.1
           args: --timeout 10m0s
+          go-version: ${{ env.go-version }}
 
   generate:
     runs-on: ${{ matrix.os }}
@@ -35,6 +37,10 @@ jobs:
     name: Generate and format
     steps:
       - uses: actions/checkout@v2
+
+      - name: Import common environment variables
+        run: cat ".github/env" >> $GITHUB_ENV
+
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ env.go-version }}
@@ -44,6 +50,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Import common environment variables
+        run: cat ".github/env" >> $GITHUB_ENV
 
       - name: Setup Go environment
         uses: actions/setup-go@v2.1.4
@@ -57,6 +66,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Import common environment variables
+        run: cat ".github/env" >> $GITHUB_ENV
+
       - name: e2e tests through OLM
         uses: ./.github/e2e-tests-olm
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,14 +3,16 @@ name: release
 on:
   push:
     branches: [main]
-env:
-  go-version: '1.17'
 
 jobs:
   e2e-tests-olm:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Import common environment variables
+        run: cat ".github/env" >> $GITHUB_ENV
+
       - name: e2e tests through OLM
         uses: ./.github/e2e-tests-olm
         with:
@@ -26,6 +28,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Import common environment variables
+        run: cat ".github/env" >> $GITHUB_ENV
 
       # Bumping the version in the next step will also run code generation scripts
       # that depend on controller-gen.
@@ -64,6 +69,9 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.REPOSITORY_PUSH_TOKEN }}
+
+      - name: Import common environment variables
+        run: cat ".github/env" >> $GITHUB_ENV
 
       # Bumping the version in the next step will also run code generation scripts
       # that depend on controller-gen.


### PR DESCRIPTION
This commit extracts the go version in a central place and imports it
into the environment from the required CI jobs.