### PR TITLE
ci: cache go dependencies when running e2e tests

### DIFF
--- a/.github/e2e-tests-olm/action.yaml
+++ b/.github/e2e-tests-olm/action.yaml
@@ -20,6 +20,9 @@ runs:
       with:
         go-version: ${{ inputs.go-version }}
 
+    - name: Use go cache
+      uses: ./.github/go-cache
+
     - uses: azure/setup-kubectl@v1
 
     - name: Start KinD

--- a/.github/go-cache/action.yaml
+++ b/.github/go-cache/action.yaml
@@ -1,0 +1,19 @@
+name: go-cache
+description: Caches go dependencies
+runs:
+  using: composite
+  steps:
+    - name: Get branch name
+      id: branch-name
+      uses: tj-actions/branch-names@v5
+
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ steps.branch-name.outputs.current_branch }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-${{ steps.branch-name.outputs.current_branch }}-
+          ${{ runner.os }}-go-main-
+          ${{ runner.os }}-go-

--- a/.github/olm-publish/action.yaml
+++ b/.github/olm-publish/action.yaml
@@ -20,6 +20,9 @@ runs:
     with:
       go-version: ${{ inputs.go-version }}
 
+  - name: Use go cache
+    uses: ./.github/go-cache
+
   - name: Registry Login
     uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
     with:


### PR DESCRIPTION
 This commit enables caching of go modules in order to speed up building
and testing the operator image. The cache load strategy tries to
load the latest cache from the current branch, then falls back to the
latest main cache from the branch and finally falls back to the latest cache
from any branch.
