### PR TITLE
feat: Deploy an Alertmanager instance for each stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ initiate-release-as: $(STANDARD_VERSION)
 	$(STANDARD_VERSION) -a --skip.tag --release-as $(RELEASE_VERSION)
 
 .PHONY: kind-cluster
-kind-cluster:
+kind-cluster: $(OPERATOR_SDK)
 	kind create cluster --config hack/kind/config.yaml
 	$(OPERATOR_SDK) olm install
 	kubectl apply -f hack/kind/registry.yaml -n operators

--- a/deploy/operator/monitoring-stack-operator-cluster-role.yaml
+++ b/deploy/operator/monitoring-stack-operator-cluster-role.yaml
@@ -36,6 +36,7 @@ rules:
   resources:
   - secrets
   - serviceaccounts
+  - services
   verbs:
   - create
   - delete
@@ -54,6 +55,7 @@ rules:
 - apiGroups:
   - monitoring.coreos.com
   resources:
+  - alertmanagers
   - prometheuses
   - servicemonitors
   verbs:

--- a/pkg/controllers/monitoring-stack/alertmanager.go
+++ b/pkg/controllers/monitoring-stack/alertmanager.go
@@ -1,0 +1,72 @@
+package monitoringstack
+
+import (
+	stack "rhobs/monitoring-stack-operator/pkg/apis/v1alpha1"
+
+	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func newAlertmanager(
+	ms *stack.MonitoringStack,
+	rbacResourceName string,
+	instanceSelectorKey string,
+	instanceSelectorValue string,
+) *monv1.Alertmanager {
+	resourceSelector := ms.Spec.ResourceSelector
+	if resourceSelector == nil {
+		resourceSelector = &metav1.LabelSelector{}
+	}
+	replicas := int32(3)
+
+	return &monv1.Alertmanager{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Alertmanager",
+			APIVersion: "monitoring.coreos.com/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ms.Name,
+			Namespace: ms.Namespace,
+			Labels:    commonLabels(ms.Name, instanceSelectorKey, instanceSelectorValue),
+		},
+		Spec: monv1.AlertmanagerSpec{
+			PodMetadata: &monv1.EmbeddedObjectMetadata{
+				Labels: commonLabels(ms.Name, instanceSelectorKey, instanceSelectorValue),
+			},
+			Replicas:                            &replicas,
+			ServiceAccountName:                  rbacResourceName,
+			AlertmanagerConfigSelector:          resourceSelector,
+			AlertmanagerConfigNamespaceSelector: nil,
+		},
+	}
+}
+
+func newAlertmanagerService(ms *stack.MonitoringStack) *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ms.Name + "-alertmanager",
+			Namespace: ms.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of": ms.Name,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"app.kubernetes.io/part-of": ms.Name,
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "web",
+					Port:       9093,
+					TargetPort: intstr.FromInt(9093),
+				},
+			},
+		},
+	}
+}

--- a/pkg/controllers/monitoring-stack/controller.go
+++ b/pkg/controllers/monitoring-stack/controller.go
@@ -56,10 +56,10 @@ type Options struct {
 //+kubebuilder:rbac:groups=monitoring.rhobs,resources=monitoringstacks,verbs=list;watch;create;update
 //+kubebuilder:rbac:groups=monitoring.rhobs,resources=monitoringstacks/status,verbs=get;update
 
-// RBAC for managing Prometheus CRs
-//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses;servicemonitors,verbs=list;watch;create;update;delete
+// RBAC for managing Prometheus Operator CRs
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=alertmanagers;prometheuses;servicemonitors,verbs=list;watch;create;update;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=list;watch;create;update;delete
-//+kubebuilder:rbac:groups="",resources=serviceaccounts;secrets,verbs=list;watch;create;update;delete
+//+kubebuilder:rbac:groups="",resources=serviceaccounts;services;secrets,verbs=list;watch;create;update;delete
 
 // RBAC for managing Grafana CRs
 //+kubebuilder:rbac:groups=integreatly.org,namespace=monitoring-stack-operator,resources=grafanadatasources,verbs=list;watch;create;update;delete


### PR DESCRIPTION
This commit adds an Alertmanager to each MonitoringStack and
configures the Prometheus instances to send alerts to that Alertmanager
instance.