### PR TITLE
ci: ensure operator has no reconcile errors

### DIFF
--- a/.github/e2e-tests-olm/action.yaml
+++ b/.github/e2e-tests-olm/action.yaml
@@ -33,11 +33,13 @@ runs:
         wait: 300s
         config: ./hack/kind/config.yaml
 
+    - name: Install required tools
+      shell: bash
+      run: make operator-sdk promq
+
     - name: Install OLM
       shell: bash
-      run: |
-        make operator-sdk
-        ./tmp/bin/operator-sdk olm install
+      run: ./tmp/bin/operator-sdk olm install
 
     - name: Create a local docker registry in the Kind cluster
       shell: bash
@@ -48,8 +50,8 @@ runs:
         echo "127.0.0.1 local-registry" | sudo tee -a /etc/hosts
 
     - name: Build images
-      run: make operator-image bundle bundle-image IMAGE_BASE="local-registry:30000/monitoring-stack-operator" VERSION=0.0.0-ci
       shell: bash
+      run: make operator-image bundle bundle-image IMAGE_BASE="local-registry:30000/monitoring-stack-operator" VERSION=0.0.0-ci
 
     - name: Wait for cluster to finish bootstraping
       shell: bash
@@ -59,8 +61,8 @@ runs:
         kubectl get pods -A
 
     - name: Publish images
-      run: make operator-push bundle-push IMAGE_BASE="local-registry:30000/monitoring-stack-operator" VERSION=0.0.0-ci
       shell: bash
+      run: make operator-push bundle-push IMAGE_BASE="local-registry:30000/monitoring-stack-operator" VERSION=0.0.0-ci
 
     - name: Deploy the operator
       shell: bash
@@ -75,6 +77,73 @@ runs:
           --namespace operators \
           --skip-tls
 
+        kubectl rollout status deployment monitoring-stack-operator -n operators
+
+    - name: Expose operator metrics endpoint
+      shell: bash
+      run: |
+        kubectl apply -n operators -f hack/kind/operator-metrics-service.yaml
+        sleep 2
+
+        # wait for the service to create an endpoint
+        while ! kubectl get -n operators ep  operator-metrics-service && [[ "$i" -le 5 ]]; do
+            (( i++ ))
+            echo " - $i ... repeat "
+            sleep 2
+        done
+
+    - name: Assert no reconciliation errors before running the test
+      shell: bash
+      run: |
+        # assert there are no reconciliation errors before running test
+        # give operator some time to start before collecting the metrics
+        sleep 5
+        ./tmp/bin/promq -t http://localhost:30001/metrics  \
+          -q 'controller_runtime_reconcile_errors_total' -o yaml
+
+        reconcile_errors=$( ./tmp/bin/promq \
+          -t http://localhost:30001/metrics  -o yaml \
+          -q 'sum(controller_runtime_reconcile_errors_total)' \
+          | tr -d ' ' | grep ^v: | cut -f2  -d: )
+
+        echo "Reconcile errors before running tests: $reconcile_errors"
+
+        if [[ "$reconcile_errors" -ne 0 ]]; then
+          kubectl logs -n operators deploy/monitoring-stack-operator
+          echo ================================================================
+          echo "Expecting 0 reconcile errors but found $reconcile_errors"
+          exit 1
+        fi
+
     - name: Run tests
       shell: bash
-      run: go test -v ./test/e2e/...
+      run: |
+        go test -v ./test/e2e/... || {
+          echo ================================================================
+          # print operator logs on failure
+          kubectl logs -n operators deploy/monitoring-stack-operator
+          exit 1
+        }
+
+    - name: Print operator logs and reconcile stats
+      shell: bash
+      run: |
+        kubectl logs -n operators deploy/monitoring-stack-operator
+        echo ================================================================
+
+        ./tmp/bin/promq -t http://localhost:30001/metrics  \
+          -q 'controller_runtime_reconcile_errors_total'
+
+    - name: Assert that there are no reconciliation errors
+      shell: bash
+      run: |
+        reconcile_errors=$( ./tmp/bin/promq \
+          -t http://localhost:30001/metrics  -o yaml \
+          -q 'sum(controller_runtime_reconcile_errors_total)' \
+          | tr -d ' ' | grep ^v: | cut -f2  -d: )
+
+        echo "Reconcile errors after test run: $reconcile_errors"
+        if [[ "$reconcile_errors" -ne 0 ]]; then
+          echo "Found $reconcile_errors reconciliation errors"
+          exit 1
+        fi

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ GOLANGCI_LINT=$(TOOLS_DIR)/golangci-lint
 KUSTOMIZE=$(TOOLS_DIR)/kustomize
 OPERATOR_SDK = $(TOOLS_DIR)/operator-sdk
 OPM = $(TOOLS_DIR)/opm
+PROMQ = $(TOOLS_DIR)/promq
 
 $(TOOLS_DIR):
 	@mkdir -p $(TOOLS_DIR)
@@ -72,9 +73,23 @@ $(OPM) opm: $(TOOLS_DIR)
 		chmod +x $(OPM) ;\
 	}
 
+.PHONY: promq
+$(PROMQ) promq: $(TOOLS_DIR)
+	@{ \
+		set -ex ;\
+		[[ -f $(PROMQ) ]] && exit 0 ;\
+		TMP_DIR=$$(mktemp -d) ;\
+		cd $$TMP_DIR ;\
+		echo "Downloading promq" ;\
+		git clone --depth=1 https://github.com/kubernetes-sigs/instrumentation-tools ;\
+		cd instrumentation-tools ;\
+		go build -o $(PROMQ) . ;\
+		rm -rf $$TMP_DIR ;\
+	}
+
 # Install all required tools
 .PHONY: tools
-tools: $(CONTROLLER_GEN) $(KUSTOMIZE) $(OPERATOR_SDK) $(OPM)
+tools: $(CONTROLLER_GEN) $(KUSTOMIZE) $(OPERATOR_SDK) $(OPM) $(PROMQ)
 
 ## Development
 

--- a/hack/kind/config.yaml
+++ b/hack/kind/config.yaml
@@ -10,6 +10,9 @@ nodes:
     extraPortMappings:
       - containerPort: 30000
         hostPort: 30000
+      # operator metrics endpoint for scrapping with promq
+      - containerPort: 30001
+        hostPort: 30001
     kubeadmConfigPatches:
       - |
         kind: ClusterConfiguration

--- a/hack/kind/operator-metrics-service.yaml
+++ b/hack/kind/operator-metrics-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: operator-metrics-service
+  labels:
+    app: operator-metrics
+spec:
+  # NOTE: 30001 must be exposed: see hack/kind/config.yaml
+  type: NodePort
+  ports:
+    - protocol: TCP
+      port: 30001
+      targetPort: 8080
+      nodePort: 30001
+  selector:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: monitoring-stack-operator

--- a/test/e2e/monitoring_stack_controller_test.go
+++ b/test/e2e/monitoring_stack_controller_test.go
@@ -194,11 +194,11 @@ func assertPrometheusScrapesItself(t *testing.T) {
 	ms := newMonitoringStack(t, "self-scrape")
 	err := f.K8sClient.Create(context.Background(), ms)
 	assert.NilError(t, err)
-	f.AssertStatefulsetReady("prometheus-self-scrape", e2eTestNamespace)(t)
+	f.AssertStatefulsetReady("prometheus-self-scrape", e2eTestNamespace, framework.WithTimeout(1*time.Minute))(t)
 
 	stopChan := make(chan struct{})
 	defer close(stopChan)
-	if err := wait.Poll(5*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+	if err := wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
 		err = f.StartServicePortForward("self-scrape-prometheus", e2eTestNamespace, "9090", stopChan)
 		return err == nil, nil
 	}); err != nil {

--- a/test/e2e/prometheus_operator_test.go
+++ b/test/e2e/prometheus_operator_test.go
@@ -2,7 +2,9 @@ package e2e
 
 import (
 	"context"
+	"rhobs/monitoring-stack-operator/test/e2e/framework"
 	"testing"
+	"time"
 
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -51,15 +53,18 @@ func TestPrometheusOperatorForNonOwnedResources(t *testing.T) {
 			scenario: func(t *testing.T) {
 				t.Run("Prometheus never exists", func(t *testing.T) {
 					t.Parallel()
-					f.AssertResourceNeverExists(prometheusStsName, e2eTestNamespace, &appsv1.StatefulSet{})(t)
+					f.AssertResourceNeverExists(prometheusStsName, e2eTestNamespace,
+						&appsv1.StatefulSet{}, framework.WithTimeout(15*time.Second))(t)
 				})
 				t.Run("Alertmanager never exists", func(t *testing.T) {
 					t.Parallel()
-					f.AssertResourceNeverExists(alertmanagerStsName, e2eTestNamespace, &appsv1.StatefulSet{})(t)
+					f.AssertResourceNeverExists(alertmanagerStsName, e2eTestNamespace,
+						&appsv1.StatefulSet{}, framework.WithTimeout(15*time.Second))(t)
 				})
 				t.Run("Thanos Ruler never exists", func(t *testing.T) {
 					t.Parallel()
-					f.AssertResourceNeverExists(thanosRulerStsName, e2eTestNamespace, &appsv1.StatefulSet{})(t)
+					f.AssertResourceNeverExists(thanosRulerStsName, e2eTestNamespace,
+						&appsv1.StatefulSet{}, framework.WithTimeout(15*time.Second))(t)
 				})
 			},
 		},


### PR DESCRIPTION
This patch makes use of promq tool to scape operator metrics to ensure
that it does not generate any reconcile errors.

Signed-off-by: Sunil Thaha <sthaha@redhat.com>