### PR TITLE
feat: query Prometheus through a dedicated service

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,9 @@ linters:
 
 issues:
   exclude-rules:
+  - path: zz_generated.deepcopy.go
+    linters:
+      - goimports
   - path: _test.go
     linters:
     - errcheck

--- a/test/e2e/framework/assertions.go
+++ b/test/e2e/framework/assertions.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -52,14 +52,14 @@ func (f *Framework) AssertResourceEventuallyExists(name string, namespace string
 	}
 }
 
-// AssertPodEventuallyRuns asserts that a pod eventually gets into a Running phase
-func (f *Framework) AssertPodEventuallyRuns(name string, namespace string) func(t *testing.T) {
+// AssertStatefulsetReady asserts that a statefulset has the desired number of pods running
+func (f *Framework) AssertStatefulsetReady(name string, namespace string) func(t *testing.T) {
 	return func(t *testing.T) {
 		key := types.NamespacedName{Name: name, Namespace: namespace}
 		if err := wait.Poll(5*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
-			pod := &corev1.Pod{}
+			pod := &appsv1.StatefulSet{}
 			err := f.K8sClient.Get(context.Background(), key, pod)
-			return err == nil && pod.Status.Phase == corev1.PodRunning, nil
+			return err == nil && pod.Status.ReadyReplicas == *pod.Spec.Replicas, nil
 		}); err != nil {
 			t.Fatal(err)
 		}

--- a/test/e2e/monitoring_stack_controller_test.go
+++ b/test/e2e/monitoring_stack_controller_test.go
@@ -194,12 +194,12 @@ func assertPrometheusScrapesItself(t *testing.T) {
 	ms := newMonitoringStack(t, "self-scrape")
 	err := f.K8sClient.Create(context.Background(), ms)
 	assert.NilError(t, err)
-	f.AssertPodEventuallyRuns("prometheus-self-scrape-0", e2eTestNamespace)(t)
+	f.AssertStatefulsetReady("prometheus-self-scrape", e2eTestNamespace)(t)
 
 	stopChan := make(chan struct{})
 	defer close(stopChan)
 	if err := wait.Poll(5*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
-		err = f.StartPortForward("prometheus-self-scrape-0", e2eTestNamespace, "9090", stopChan)
+		err = f.StartServicePortForward("self-scrape-prometheus", e2eTestNamespace, "9090", stopChan)
 		return err == nil, nil
 	}); err != nil {
 		t.Fatal(err)
@@ -233,12 +233,12 @@ func assertAlertmanagerReceivesAlerts(t *testing.T) {
 	if err := f.K8sClient.Create(context.Background(), rule); err != nil {
 		t.Fatal(err)
 	}
-	f.AssertPodEventuallyRuns("alertmanager-alerting-0", e2eTestNamespace)(t)
+	f.AssertStatefulsetReady("alertmanager-alerting", e2eTestNamespace)(t)
 
 	stopChan := make(chan struct{})
 	defer close(stopChan)
 	if err := wait.Poll(5*time.Second, 5*time.Minute, func() (bool, error) {
-		err := f.StartPortForward("alertmanager-alerting-0", e2eTestNamespace, "9093", stopChan)
+		err := f.StartServicePortForward("alerting-alertmanager", e2eTestNamespace, "9093", stopChan)
 		return err == nil, nil
 	}); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The prometheus-operated service is a statefulset governing service. It
is intended to be used by the statefulset controller for assigning a
network identity to individual pods, and is not supposed to be used for
http communication.

This commit creates a dedicated service for each Prometheus statefulset
and reconfigures the GrafanaDataSource to query it instead.