### PR TITLE
fix: use api-version from scheme information

### DIFF
--- a/pkg/controllers/grafana-operator/controller.go
+++ b/pkg/controllers/grafana-operator/controller.go
@@ -258,7 +258,7 @@ func (r *reconciler) reconcileGrafana(ctx context.Context) error {
 func NewNamespace() *corev1.Namespace {
 	return &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
+			APIVersion: corev1.SchemeGroupVersion.String(),
 			Kind:       "Namespace",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -270,7 +270,7 @@ func NewNamespace() *corev1.Namespace {
 func NewSubscription() *v1alpha1.Subscription {
 	return &v1alpha1.Subscription{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "operators.coreos.com/v1alpha1",
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
 			Kind:       "Subscription",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -291,7 +291,7 @@ func NewSubscription() *v1alpha1.Subscription {
 func NewOperatorGroup() *operatorsv1.OperatorGroup {
 	return &operatorsv1.OperatorGroup{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "operators.coreos.com/operatorsv1",
+			APIVersion: operatorsv1.SchemeGroupVersion.String(),
 			Kind:       "OperatorGroup",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -314,7 +314,7 @@ func newGrafana() *integreatlyv1alpha1.Grafana {
 	maxSurge := intstr.FromInt(1)
 	return &integreatlyv1alpha1.Grafana{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "integreatly.org/v1alpha1",
+			APIVersion: integreatlyv1alpha1.GroupVersion.String(),
 			Kind:       "Grafana",
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/monitoring-stack/alertmanager.go
+++ b/pkg/controllers/monitoring-stack/alertmanager.go
@@ -23,8 +23,8 @@ func newAlertmanager(
 
 	return &monv1.Alertmanager{
 		TypeMeta: metav1.TypeMeta{
+			APIVersion: monv1.SchemeGroupVersion.String(),
 			Kind:       "Alertmanager",
-			APIVersion: "monitoring.coreos.com/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ms.Name,
@@ -46,7 +46,7 @@ func newAlertmanager(
 func newAlertmanagerService(ms *stack.MonitoringStack) *corev1.Service {
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
+			APIVersion: corev1.SchemeGroupVersion.String(),
 			Kind:       "Service",
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/monitoring-stack/components.go
+++ b/pkg/controllers/monitoring-stack/components.go
@@ -265,7 +265,8 @@ func newGrafanaDataSource(ms *stack.MonitoringStack) *grafanav1alpha1.GrafanaDat
 	prometheusURL := fmt.Sprintf("prometheus-operated.%s:9090", ms.GetNamespace())
 	return &grafanav1alpha1.GrafanaDataSource{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "integreatly.org/v1alpha1",
+			// NOTE: uses a different naming convention for SchemeGroupVersion
+			APIVersion: grafanav1alpha1.GroupVersion.String(),
 			Kind:       "GrafanaDataSource",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -290,7 +291,7 @@ func newGrafanaDataSource(ms *stack.MonitoringStack) *grafanav1alpha1.GrafanaDat
 func newPrometheusRole(ms *stack.MonitoringStack, rbacResourceName string, rbacVerbs []string) *rbacv1.Role {
 	return &rbacv1.Role{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "rbac.authorization.k8s.io/v1",
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
 			Kind:       "Role",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -315,7 +316,7 @@ func newPrometheusRole(ms *stack.MonitoringStack, rbacResourceName string, rbacV
 func newServiceAccount(name string, namespace string) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
+			APIVersion: corev1.SchemeGroupVersion.String(),
 			Kind:       "ServiceAccount",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -338,8 +339,8 @@ func newPrometheus(
 	}
 	prometheus := &monv1.Prometheus{
 		TypeMeta: metav1.TypeMeta{
+			APIVersion: monv1.SchemeGroupVersion.String(),
 			Kind:       "Prometheus",
-			APIVersion: "monitoring.coreos.com/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ms.Name,
@@ -392,7 +393,7 @@ func newPrometheus(
 func newRoleBinding(ms *stack.MonitoringStack, rbacResourceName string) *rbacv1.RoleBinding {
 	roleBinding := &rbacv1.RoleBinding{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "rbac.authorization.k8s.io/v1",
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
 			Kind:       "RoleBinding",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -401,14 +402,14 @@ func newRoleBinding(ms *stack.MonitoringStack, rbacResourceName string) *rbacv1.
 		},
 		Subjects: []rbacv1.Subject{
 			{
-				APIGroup:  "",
+				APIGroup:  corev1.SchemeGroupVersion.Group,
 				Kind:      "ServiceAccount",
 				Name:      rbacResourceName,
 				Namespace: ms.Namespace,
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
+			APIGroup: rbacv1.SchemeGroupVersion.Group,
 			Kind:     "Role",
 			Name:     rbacResourceName,
 		},
@@ -419,7 +420,7 @@ func newRoleBinding(ms *stack.MonitoringStack, rbacResourceName string) *rbacv1.
 func newAdditionalScrapeConfigsSecret(ms *stack.MonitoringStack, name string) *corev1.Secret {
 	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
+			APIVersion: corev1.SchemeGroupVersion.String(),
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/grafana_operator_test.go
+++ b/test/e2e/grafana_operator_test.go
@@ -110,7 +110,7 @@ func TestGrafanaOperatorForResourcesOutsideOfItsOwnNamespace(t *testing.T) {
 func newGrafana(namespace string) *v1alpha1.Grafana {
 	return &v1alpha1.Grafana{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "integreatly.org/v1alpha1",
+			APIVersion: v1alpha1.GroupVersion.String(),
 			Kind:       "Grafana",
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -65,7 +65,7 @@ func setupFramework() error {
 func createNamespace(name string) (func(), error) {
 	ns := &v1.Namespace{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
+			APIVersion: v1.SchemeGroupVersion.String(),
 			Kind:       "Namespace",
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/monitoring_stack_controller_test.go
+++ b/test/e2e/monitoring_stack_controller_test.go
@@ -287,7 +287,7 @@ func getAlertmanagerAlerts() ([]alert, error) {
 func newAlerts(t *testing.T) *monv1.PrometheusRule {
 	rule := &monv1.PrometheusRule{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "monitoring.coreos.com/v1",
+			APIVersion: monv1.SchemeGroupVersion.String(),
 			Kind:       "PrometheusRule",
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/prometheus_operator_test.go
+++ b/test/e2e/prometheus_operator_test.go
@@ -110,7 +110,7 @@ func TestPrometheusOperatorForOwnedResources(t *testing.T) {
 func newPrometheus(labels map[string]string) *v1.Prometheus {
 	return &v1.Prometheus{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "monitoring.coreos.com/v1",
+			APIVersion: v1.SchemeGroupVersion.String(),
 			Kind:       "Prometheus",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -124,7 +124,7 @@ func newPrometheus(labels map[string]string) *v1.Prometheus {
 func newAlertmanager(labels map[string]string) *v1.Alertmanager {
 	return &v1.Alertmanager{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "monitoring.coreos.com/v1",
+			APIVersion: v1.SchemeGroupVersion.String(),
 			Kind:       "Prometheus",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -138,7 +138,7 @@ func newAlertmanager(labels map[string]string) *v1.Alertmanager {
 func newThanosRuler(labels map[string]string) *v1.ThanosRuler {
 	return &v1.ThanosRuler{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "monitoring.coreos.com/v1",
+			APIVersion: v1.SchemeGroupVersion.String(),
 			Kind:       "Prometheus",
 		},
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Replaces all hard-coded APIVersion: "group/version" with
`package.SchemeGroupVersion.String()` to prevent any typos and to use the
computed value.

Signed-off-by: Sunil Thaha <sthaha@redhat.com>