### PR TITLE
ci: capture cluster state after e2e run

### DIFF
--- a/.github/e2e-tests-olm/action.yaml
+++ b/.github/e2e-tests-olm/action.yaml
@@ -117,13 +117,7 @@ runs:
 
     - name: Run tests
       shell: bash
-      run: |
-        go test -v ./test/e2e/... || {
-          echo ================================================================
-          # print operator logs on failure
-          kubectl logs -n operators deploy/monitoring-stack-operator
-          exit 1
-        }
+      run: go test -v -failfast ./test/e2e/... --retain=true
 
     - name: Print operator logs and reconcile stats
       shell: bash
@@ -147,3 +141,20 @@ runs:
           echo "Found $reconcile_errors reconciliation errors"
           exit 1
         fi
+
+    - name: Capture cluster state
+      if: always()
+      shell: bash
+      run: |
+        # Output operator logs
+        kubectl logs -n operators deploy/monitoring-stack-operator
+        # Capture apiserver state
+        make oc
+        oc adm inspect -A ns --dest-dir cluster-state || true
+
+    - name: Archive production artifacts
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: cluster-state
+        path: cluster-state

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ KUSTOMIZE=$(TOOLS_DIR)/kustomize
 OPERATOR_SDK = $(TOOLS_DIR)/operator-sdk
 OPM = $(TOOLS_DIR)/opm
 PROMQ = $(TOOLS_DIR)/promq
+OC = $(TOOLS_DIR)/oc
 
 $(TOOLS_DIR):
 	@mkdir -p $(TOOLS_DIR)
@@ -85,6 +86,16 @@ $(PROMQ) promq: $(TOOLS_DIR)
 		cd instrumentation-tools ;\
 		go build -o $(PROMQ) . ;\
 		rm -rf $$TMP_DIR ;\
+	}
+
+.PHONY: oc
+$(OC) oc: $(TOOLS_DIR)
+	@{ \
+		set -ex ;\
+		[[ -f $(OC) ]] && exit 0 ;\
+		OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
+		curl -sSLo $(OC) https://mirror.openshift.com/pub/openshift-v4/$${ARCH}/clients/oc/latest/$${OS}/oc.tar.gz ;\
+		tar -xf $(TOOLS_DIR)/oc -C $(TOOLS_DIR) ;\
 	}
 
 # Install all required tools

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -20,6 +21,7 @@ import (
 type Framework struct {
 	Config    *rest.Config
 	K8sClient client.Client
+	Retain    bool
 }
 
 // StartPortForward initiates a port forwarding connection to a pod on the localhost interface.
@@ -84,4 +86,11 @@ func (f *Framework) getPodsForService(name string, namespace string) ([]corev1.P
 	}
 
 	return pods.Items, nil
+}
+
+func (f *Framework) CleanUp(t *testing.T, cleanupFunc func()) {
+	testSucceeded := !t.Failed()
+	if testSucceeded || !f.Retain {
+		t.Cleanup(cleanupFunc)
+	}
 }

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"flag"
 	"log"
 	"os"
 	"rhobs/monitoring-stack-operator/pkg/operator"
@@ -21,7 +22,10 @@ var (
 
 const e2eTestNamespace = "e2e-tests"
 
+var retain = flag.Bool("retain", false, "When set, the namespace in which tests are run will not be cleaned up")
+
 func TestMain(m *testing.M) {
+	flag.Parse()
 
 	// Deferred calls are not executed on os.Exit from TestMain.
 	// As a workaround, we call another function in which we can add deferred calls.
@@ -41,7 +45,10 @@ func main(m *testing.M) int {
 		log.Println(err)
 		return 1
 	}
-	defer cleanup()
+	if !*retain {
+		defer cleanup()
+	}
+
 	return m.Run()
 }
 
@@ -57,6 +64,7 @@ func setupFramework() error {
 	f = &framework.Framework{
 		K8sClient: k8sClient,
 		Config:    cfg,
+		Retain:    *retain,
 	}
 
 	return nil

--- a/test/e2e/monitoring_stack_controller_test.go
+++ b/test/e2e/monitoring_stack_controller_test.go
@@ -315,7 +315,7 @@ func newAlerts(t *testing.T) *monv1.PrometheusRule {
 			},
 		},
 	}
-	t.Cleanup(func() {
+	f.CleanUp(t, func() {
 		f.K8sClient.Delete(context.Background(), rule)
 	})
 
@@ -329,8 +329,9 @@ func newMonitoringStack(t *testing.T, name string) *stack.MonitoringStack {
 			Namespace: e2eTestNamespace,
 		},
 	}
-	t.Cleanup(func() {
+	f.CleanUp(t, func() {
 		f.K8sClient.Delete(context.Background(), ms)
 	})
+
 	return ms
 }


### PR DESCRIPTION
Flaky tests can be hard to troubleshoot in the CI. This commit adds a
step in the pipeline which captures the cluster-state after each e2e
test run. It also adds a --retain-namespace flag which is toggled in the
pipeline to prevent deletion of the e2e-tests namespace.