### PR TITLE
ci: cache development tools

### DIFF
--- a/.github/e2e-tests-olm/action.yaml
+++ b/.github/e2e-tests-olm/action.yaml
@@ -34,8 +34,7 @@ runs:
         config: ./hack/kind/config.yaml
 
     - name: Install required tools
-      shell: bash
-      run: make operator-sdk promq oc
+      uses: ./.github/tools-cache
 
     - name: Install OLM
       shell: bash

--- a/.github/olm-publish/action.yaml
+++ b/.github/olm-publish/action.yaml
@@ -23,6 +23,9 @@ runs:
   - name: Use go cache
     uses: ./.github/go-cache
 
+  - name: Install tools
+    uses: ./.github/tools-cache
+
   - name: Registry Login
     uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
     with:

--- a/.github/tools
+++ b/.github/tools
@@ -1,0 +1,6 @@
+controller-gen v0.7.0
+kustomize v3.9.4
+oc v4.9.7
+operator-sdk v1.13.0
+opm v1.15.1
+promq v0.0.1

--- a/.github/tools-cache/action.yaml
+++ b/.github/tools-cache/action.yaml
@@ -1,0 +1,32 @@
+name: tools-cache
+description: Caches develoment tools
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@v2
+      id: tools-cache
+      with:
+        path: ./tmp/bin
+        key: ${{ runner.os }}-tools-${{ hashFiles('.github/tools') }}
+
+    - name: Install Dependencies
+      if: steps.tools-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: make tools
+
+    - name: Show version info of tools
+      shell: bash
+      run: |
+        # verify if the restored/downloaded tools run properly
+
+        ls ./tmp/bin
+        echo -------------------------------------------
+
+        ./tmp/bin/controller-gen --version
+        ./tmp/bin/kustomize version
+        ./tmp/bin/oc version
+        ./tmp/bin/operator-sdk version
+        ./tmp/bin/opm version
+        ./tmp/bin/promq --help | head -n2
+
+        echo "---------- done ------------"

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -44,7 +44,32 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ env.go-version }}
+
+      - name: Use go cache
+        uses: ./.github/go-cache
+
       - run: make --always-make generate && git diff --exit-code
+
+  tool-versions:
+    runs-on: ubuntu-latest
+    name: Validate tools cache
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Import common environment variables
+        run: cat ".github/env" >> $GITHUB_ENV
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.go-version }}
+
+      - name: Use go cache
+        uses: ./.github/go-cache
+
+      - name: Use tools cache
+        uses: ./.github/tools-cache
+
+      - run: make --always-make tools && git diff --exit-code
 
   build-bundle-image:
     runs-on: ubuntu-latest
@@ -58,6 +83,12 @@ jobs:
         uses: actions/setup-go@v2.1.4
         with:
           go-version: ${{ env.go-version }}
+
+      - name: Use go cache
+        uses: ./.github/go-cache
+
+      - name: Install tools
+        uses: ./.github/tools-cache
 
       - name: Build Bundle Image
         run: make bundle-image


### PR DESCRIPTION
Previously, we have seen that downloading of tools like `oc` can fail due to 
transient errors. These tools are downloaded for every CI run and do not change
often. 

This PR reduces the need to download these tools over and over by making use
of  github's cache to cache all the tools downloaded by `make tools`. The cache
relies on the checksum of `.github/tools` file as key, so  any change to the 
`.github/tools` file will result in a new set of tools being downloaded.
