### PR TITLE
chore: Recommend to use k8s v1.22 image for kind cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ SHELL=/usr/bin/env bash -o pipefail
 # This variable is used to construct full image tags for bundle and catalog images.
 IMAGE_BASE ?= monitoring-stack-operator
 
-
 VERSION ?= $(shell cat VERSION)
 OPERATOR_IMG = $(IMAGE_BASE):$(VERSION)
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,10 @@ to the controller-gen CLI page in the [kubebuilder documentation](https://book.k
 
 * Install [kind](https://github.com/kubernetes-sigs/kind)
 
-* Create a local kubernetes cluster with `kind create cluster`.
+* Create a local kubernetes cluster with kind node image >= v1.22, older images seem to have issues with OLM installation.
+  ```sh
+  kind create cluster --image kindest/node:v1.22.4
+  ```
 
 * Apply the CRDs by running `kubectl create -k deploy/crds/kubernetes`
   * Install OLM locally by running
@@ -58,7 +61,7 @@ to the controller-gen CLI page in the [kubebuilder documentation](https://book.k
 
 * Apply the dependecies; i.e - Prometheus Operator and Grafana Operator by running
 
-    ```go
+    ```sh
     kubectl apply -k deploy/dependencies
     ```
 

--- a/hack/kind/config.yaml
+++ b/hack/kind/config.yaml
@@ -13,6 +13,7 @@ nodes:
       # operator metrics endpoint for scrapping with promq
       - containerPort: 30001
         hostPort: 30001
+    image: kindest/node:v1.22.4
     kubeadmConfigPatches:
       - |
         kind: ClusterConfiguration


### PR DESCRIPTION
k8s v1.21 image has issues with OLM installation. See https://github.com/orgs/rhobs/teams/monitoring-stack-operator-maintainers/discussions/1

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>