### PR TITLE
fix: prevent automatic upgrades of Grafana Operator

### DIFF
--- a/deploy/operator/monitoring-stack-operator-cluster-role.yaml
+++ b/deploy/operator/monitoring-stack-operator-cluster-role.yaml
@@ -131,6 +131,14 @@ rules:
 - apiGroups:
   - operators.coreos.com
   resources:
+  - installplans
+  verbs:
+  - list
+  - update
+  - watch
+- apiGroups:
+  - operators.coreos.com
+  resources:
   - operatorgroups
   - subscriptions
   verbs:

--- a/hack/grafana-dashboard.yaml
+++ b/hack/grafana-dashboard.yaml
@@ -1,0 +1,37 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: simple-dashboard
+  labels:
+    app.kubernetes.io/part-of: monitoring-stack-operator
+spec:
+  json: >
+    {
+      "id": null,
+      "title": "Simple Dashboard",
+      "tags": [],
+      "style": "dark",
+      "timezone": "browser",
+      "editable": true,
+      "hideControls": false,
+      "graphTooltip": 1,
+      "panels": [],
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {
+        "time_options": [],
+        "refresh_intervals": []
+      },
+      "templating": {
+        "list": []
+      },
+      "annotations": {
+        "list": []
+      },
+      "refresh": "5s",
+      "schemaVersion": 17,
+      "version": 0,
+      "links": []
+    }


### PR DESCRIPTION
The Grafana Operator is a third party bundle and its releases are not in
our control. The 4.0.2 release was buggy and should not have been used at all.

This commit makes sure that new versions are not installed
automatically.