### PR TITLE
docs: auto generate CRD docs

### DIFF
--- a/.github/tools
+++ b/.github/tools
@@ -6,6 +6,7 @@ oc v4.8.11
 operator-sdk v1.13.0
 opm v1.15.1
 promq v0.0.1
+crdoc v0.5.2
 jsonnet v0.17.0
 jsonnetfmt v0.17.0
 jsonnet-lint v0.17.0

--- a/.github/tools-cache/action.yaml
+++ b/.github/tools-cache/action.yaml
@@ -17,19 +17,5 @@ runs:
     - name: Show version info of tools
       shell: bash
       run: |
-        # verify if the restored/downloaded tools run properly
-
         ls ./tmp/bin
-        echo -------------------------------------------
-
-        ./tmp/bin/controller-gen --version
-        ./tmp/bin/kustomize version
-        ./tmp/bin/oc version
-        ./tmp/bin/operator-sdk version
-        ./tmp/bin/opm version
-        ./tmp/bin/promq --help | head -n2
-        ./tmp/bin/jsonnetfmt --version
-        ./tmp/bin/jsonnet-lint --version
-        ./tmp/bin/jb --version
-
-        echo "---------- done ------------"
+        make validate-tools

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 SHELL=/usr/bin/env bash -o pipefail
 
+include Makefile.tools
+
 # IMAGE_BASE defines the registry/namespace and part of the image name
 # This variable is used to construct full image tags for bundle and catalog images.
 IMAGE_BASE ?= monitoring-stack-operator
@@ -9,190 +11,6 @@ OPERATOR_IMG = $(IMAGE_BASE):$(VERSION)
 
 # running `make` builds the operator (default target)
 all: operator
-
-## Tools
-TOOLS_DIR = $(shell pwd)/tmp/bin
-
-## NOTE: each tool must have a version that will be recorded in .github/tools
-# The .github/tools file's hash is used to compute the key for cache in github
-# see: .github/tools-cache/action.yaml
-
-CONTROLLER_GEN = $(TOOLS_DIR)/controller-gen
-CONTROLLER_GEN_VERSION = v0.7.0
-
-KUSTOMIZE = $(TOOLS_DIR)/kustomize
-KUSTOMIZE_VERSION = v3.9.4
-
-OPERATOR_SDK = $(TOOLS_DIR)/operator-sdk
-OPERATOR_SDK_VERSION = v1.13.0
-
-OPM = $(TOOLS_DIR)/opm
-OPM_VERSION = v1.15.1
-
-GOLANGCI_LINT = $(TOOLS_DIR)/golangci-lint
-GOLANGCI_LINT_VERSION = v1.42.1
-
-## NOTE: promq does not have any releases, so we use a fake version starting with v0.0.1
-# thus to upgrade/invalidate the github cache, increment the value
-PROMQ = $(TOOLS_DIR)/promq
-PROMQ_VERSION = v0.0.1
-
-# NOTE: oc is NOT downloadable using the OC_VERSION in its URL, so this has to be manually updated
-OC = $(TOOLS_DIR)/oc
-OC_VERSION = v4.8.11
-
-# jsonnet related tools and dependencies
-JSONNET = $(TOOLS_DIR)/jsonnet
-JSONNET_VERSION = v0.17.0
-
-JSONNETFMT = $(TOOLS_DIR)/jsonnetfmt
-JSONNETFMT_VERSION = v0.17.0
-
-JSONNET_LINT = $(TOOLS_DIR)/jsonnet-lint
-JSONNET_LINT_VERSION = v0.17.0
-
-JB = $(TOOLS_DIR)/jb
-JB_VERSION = v0.4.0
-
-## NOTE: gojsontoyaml does not have any releases, so we use a fake version starting with v0.0.1
-# thus to upgrade/invalidate the github cache, increment the value
-GOJSONTOYAML = $(TOOLS_DIR)/gojsontoyaml
-GOJSONTOYAML_VERSRION = 0.0.1
-
-JSONNET_VENDOR = jsonnet/vendor
-JSONNETFMT_ARGS = -n 2 --max-blank-lines 2 --string-style s --comment-style s
-
-$(TOOLS_DIR):
-	@mkdir -p $(TOOLS_DIR)
-
-.PHONY: controller-gen
-$(CONTROLLER_GEN) controller-gen: $(TOOLS_DIR)
-	@{ \
-		set -ex ;\
-		GOBIN=$(TOOLS_DIR) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION) ;\
-	}
-
-.PHONY: golangci-lint
-$(GOLANGCI_LINT) golangci-lint: $(TOOLS_DIR)
-	@{ \
-		set -ex ;\
-		GOBIN=$(TOOLS_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) ;\
-	}
-
-# NOTE: kustomize does not support `go install` hence this workaround to install
-# it by creating an tmp module and using go get to download the precise version
-# needed for the project
-# see: https://github.com/kubernetes-sigs/kustomize/issues/3618
-.PHONY: kustomize
-$(KUSTOMIZE) kustomize: $(TOOLS_DIR)
-	@{ \
-		set -ex ;\
-		[[ -f $(KUSTOMIZE) ]] && exit 0 ;\
-		TMP_DIR=$$(mktemp -d) ;\
-		cd $$TMP_DIR ;\
-		go mod init tmp ;\
-		echo "Downloading kustomize" ;\
-		GOBIN=$(TOOLS_DIR) go get sigs.k8s.io/kustomize/kustomize/v3@$(KUSTOMIZE_VERSION) ;\
-		rm -rf $$TMP_DIR ;\
-	}
-
-.PHONY: operator-sdk
-$(OPERATOR_SDK) operator-sdk: $(TOOLS_DIR)
-	@{ \
-		set -ex ;\
-		[[ -f $(OPERATOR_SDK) ]] && exit 0 ;\
-		OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-		curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
-		chmod +x $(OPERATOR_SDK) ;\
-	}
-
-.PHONY: opm
-$(OPM) opm: $(TOOLS_DIR)
-	@{ \
-		set -ex ;\
-		[[ -f $(OPM) ]] && exit 0 ;\
-		OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-		curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$${OS}-$${ARCH}-opm ;\
-		chmod +x $(OPM) ;\
-	}
-
-.PHONY: promq
-$(PROMQ) promq: $(TOOLS_DIR)
-	@{ \
-		set -ex ;\
-		[[ -f $(PROMQ) ]] && exit 0 ;\
-		TMP_DIR=$$(mktemp -d) ;\
-		cd $$TMP_DIR ;\
-		echo "Downloading promq" ;\
-		git clone --depth=1 https://github.com/kubernetes-sigs/instrumentation-tools ;\
-		cd instrumentation-tools ;\
-		go build -o $(PROMQ) . ;\
-		rm -rf $$TMP_DIR ;\
-	}
-
-.PHONY: oc
-$(OC) oc: $(TOOLS_DIR)
-	@{ \
-		set -ex ;\
-		[[ -f $(OC) ]] && exit 0 ;\
-		OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-		curl -sSLo $(OC) https://mirror.openshift.com/pub/openshift-v4/$${ARCH}/clients/oc/latest/$${OS}/oc.tar.gz ;\
-		tar -xf $(TOOLS_DIR)/oc -C $(TOOLS_DIR) ;\
-		rm -f $(TOOLS_DIR)/README.md ;\
-		$(OC) version ;\
-		version=$(OC_VERSION) ;\
-		$(OC) version | grep -q $${version##v} ;\
-	}
-
-.PHONY: jsonnet
-$(JSONNET) jsonnet: $(TOOLS_DIR)
-		GOBIN=$(TOOLS_DIR) go install github.com/google/go-jsonnet/cmd/jsonnet@latest
-
-.PHONY: jsonnetfmt
-$(JSONNETFMT) jsonnetfmt: $(TOOLS_DIR)
-		GOBIN=$(TOOLS_DIR)  go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
-
-.PHONY: jsonnet-lint
-$(JSONNET_LINT) jsonnet-lint: $(TOOLS_DIR)
-	GOBIN=$(TOOLS_DIR)  go install github.com/google/go-jsonnet/cmd/jsonnet-lint@latest
-
-.PHONY: jb
-$(JB) jb: $(TOOLS_DIR)
-	GOBIN=$(TOOLS_DIR) go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
-
-.PHONY: gojsontoyaml
-$(GOJSONTOYAML) gojsontoyaml: $(TOOLS_DIR)
-	GOBIN=$(TOOLS_DIR) go install github.com/brancz/gojsontoyaml@latest
-
-.PHONY: jsonnet-tools
-jsonnet-tools: jsonnet jsonnetfmt jsonnet-lint jb gojsontoyaml
-
-# Install all required tools
-.PHONY: tools
-tools: $(CONTROLLER_GEN) \
- 		$(KUSTOMIZE) \
-		$(OC) \
-		$(OPERATOR_SDK) \
-		$(OPM) \
-		$(PROMQ) \
-		jsonnet-tools
-	@{ \
-		set -ex ;\
-		tools_file=.github/tools ;\
-		echo '# DO NOT EDIT! Autogenerated by make tools' >$$tools_file ;\
-		echo >> $$tools_file ;\
-		echo  $$(basename $(CONTROLLER_GEN)) $(CONTROLLER_GEN_VERSION) >> $$tools_file ;\
-		echo  $$(basename $(KUSTOMIZE)) $(KUSTOMIZE_VERSION) >> $$tools_file ;\
-		echo  $$(basename $(OC)) $(OC_VERSION) >> $$tools_file ;\
-		echo  $$(basename $(OPERATOR_SDK)) $(OPERATOR_SDK_VERSION) >> $$tools_file ;\
-		echo  $$(basename $(OPM)) $(OPM_VERSION) >> $$tools_file ;\
-		echo  $$(basename $(PROMQ)) $(PROMQ_VERSION) >> $$tools_file ;\
-		echo  $$(basename $(JSONNET)) $(JSONNET_VERSION) >> $$tools_file ;\
-		echo  $$(basename $(JSONNETFMT)) $(JSONNETFMT_VERSION) >> $$tools_file ;\
-		echo  $$(basename $(JSONNET_LINT)) $(JSONNET_LINT_VERSION) >> $$tools_file ;\
-		echo  $$(basename $(JB)) $(JB_VERSION) >> $$tools_file ;\
-		echo  $$(basename $(GOJSONTOYAML)) $(GOJSONTOYAML_VERSRION) >> $$tools_file ;\
-	}
 
 ## Development
 
@@ -238,6 +56,11 @@ generate-prometheus-rules: jsonnet-tools check-jq kustomize jsonnet-vendor
 		$(KUSTOMIZE) edit add resource "monitoring-stack-operator-$$component-rules.yaml" && cd - ;\
 	done;
 
+.PHONY: docs
+docs: $(CRDOC)
+	mkdir -p docs
+	$(CRDOC) --resources deploy/crds/common --output docs/api.md
+
 .PHONY: generate-crds
 generate-crds: $(CONTROLLER_GEN)
 	$(CONTROLLER_GEN) crd \
@@ -259,7 +82,7 @@ generate-deepcopy: $(CONTROLLER_GEN)
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./pkg/apis/..."
 
 .PHONY: generate
-generate: generate-crds generate-deepcopy generate-kustomize generate-prometheus-rules
+generate: generate-crds generate-deepcopy generate-kustomize generate-prometheus-rules docs
 
 operator: generate
 	go build -o ./tmp/operator ./cmd/operator/...

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -1,0 +1,211 @@
+SHELL=/usr/bin/env bash -o pipefail
+
+## Tools
+TOOLS_DIR = $(shell pwd)/tmp/bin
+
+## NOTE: each tool must have a version that will be recorded in .github/tools
+# The .github/tools file's hash is used to compute the key for cache in github
+# see: .github/tools-cache/action.yaml
+
+CONTROLLER_GEN=$(TOOLS_DIR)/controller-gen
+CONTROLLER_GEN_VERSION= v0.7.0
+
+KUSTOMIZE=$(TOOLS_DIR)/kustomize
+KUSTOMIZE_VERSION= v3.9.4
+
+OPERATOR_SDK = $(TOOLS_DIR)/operator-sdk
+OPERATOR_SDK_VERSION = v1.13.0
+
+OPM=$(TOOLS_DIR)/opm
+OPM_VERSION = v1.15.1
+
+GOLANGCI_LINT=$(TOOLS_DIR)/golangci-lint
+GOLANGCI_LINT_VERSION = v1.42.1
+
+## NOTE: promq does not have any releases, so we use a fake version starting with v0.0.1
+# thus to upgrade/invalidate the github cache, increment the value
+PROMQ = $(TOOLS_DIR)/promq
+PROMQ_VERSION = v0.0.1
+
+# NOTE: oc is NOT downloadable using the OC_VERSION in its URL, so this has to be manually updated
+OC = $(TOOLS_DIR)/oc
+OC_VERSION = v4.8.11
+
+CRDOC = $(TOOLS_DIR)/crdoc
+CRDOC_VERSION = v0.5.2
+
+# jsonnet related tools and dependencies
+JSONNET = $(TOOLS_DIR)/jsonnet
+JSONNET_VERSION = v0.17.0
+
+JSONNETFMT = $(TOOLS_DIR)/jsonnetfmt
+JSONNETFMT_VERSION = v0.17.0
+
+JSONNET_LINT = $(TOOLS_DIR)/jsonnet-lint
+JSONNET_LINT_VERSION = v0.17.0
+
+JB = $(TOOLS_DIR)/jb
+JB_VERSION = v0.4.0
+
+## NOTE: gojsontoyaml does not have any releases, so we use a fake version starting with v0.0.1
+# thus to upgrade/invalidate the github cache, increment the value
+GOJSONTOYAML = $(TOOLS_DIR)/gojsontoyaml
+GOJSONTOYAML_VERSRION = 0.0.1
+
+JSONNET_VENDOR = jsonnet/vendor
+JSONNETFMT_ARGS = -n 2 --max-blank-lines 2 --string-style s --comment-style s
+
+$(TOOLS_DIR):
+	@mkdir -p $(TOOLS_DIR)
+
+.PHONY: controller-gen
+$(CONTROLLER_GEN) controller-gen: $(TOOLS_DIR)
+	@{ \
+		set -ex ;\
+		GOBIN=$(TOOLS_DIR) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION) ;\
+	}
+
+.PHONY: golangci-lint
+$(GOLANGCI_LINT) golangci-lint: $(TOOLS_DIR)
+	@{ \
+		set -ex ;\
+		GOBIN=$(TOOLS_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) ;\
+	}
+
+# NOTE: kustomize does not support `go install` hence this workaround to install
+# it by creating an tmp module and using go get to download the precise version
+# needed for the project
+# see: https://github.com/kubernetes-sigs/kustomize/issues/3618
+.PHONY: kustomize
+$(KUSTOMIZE) kustomize: $(TOOLS_DIR)
+	@{ \
+		set -ex ;\
+		[[ -f $(KUSTOMIZE) ]] && exit 0 ;\
+		TMP_DIR=$$(mktemp -d) ;\
+		cd $$TMP_DIR ;\
+		go mod init tmp ;\
+		echo "Downloading kustomize" ;\
+		GOBIN=$(TOOLS_DIR) go get sigs.k8s.io/kustomize/kustomize/v3@$(KUSTOMIZE_VERSION) ;\
+		rm -rf $$TMP_DIR ;\
+	}
+
+.PHONY: operator-sdk
+$(OPERATOR_SDK) operator-sdk: $(TOOLS_DIR)
+	@{ \
+		set -ex ;\
+		[[ -f $(OPERATOR_SDK) ]] && exit 0 ;\
+		OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
+		curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
+		chmod +x $(OPERATOR_SDK) ;\
+	}
+
+.PHONY: opm
+$(OPM) opm: $(TOOLS_DIR)
+	@{ \
+		[[ -f $(OPM) ]] && exit 0 ;\
+		set -ex ;\
+		OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
+		curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$${OS}-$${ARCH}-opm ;\
+		chmod +x $(OPM) ;\
+	}
+
+.PHONY: promq
+$(PROMQ) promq: $(TOOLS_DIR)
+	@{ \
+		set -ex ;\
+		[[ -f $(PROMQ) ]] && exit 0 ;\
+		TMP_DIR=$$(mktemp -d) ;\
+		cd $$TMP_DIR ;\
+		echo "Downloading promq" ;\
+		git clone --depth=1 https://github.com/kubernetes-sigs/instrumentation-tools ;\
+		cd instrumentation-tools ;\
+		go build -o $(PROMQ) . ;\
+		rm -rf $$TMP_DIR ;\
+	}
+
+.PHONY: oc
+$(OC) oc: $(TOOLS_DIR)
+	@{ \
+		set -ex ;\
+		[[ -f $(OC) ]] && exit 0 ;\
+		OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
+		curl -sSLo $(OC) https://mirror.openshift.com/pub/openshift-v4/$${ARCH}/clients/oc/latest/$${OS}/oc.tar.gz ;\
+		tar -xf $(TOOLS_DIR)/oc -C $(TOOLS_DIR) ;\
+		rm -f $(TOOLS_DIR)/README.md ;\
+		$(OC) version ;\
+		version=$(OC_VERSION) ;\
+		$(OC) version | grep -q $${version##v} ;\
+	}
+
+.PHONY: crdoc
+$(CRDOC) crdoc: $(TOOLS_DIR)
+	@{ \
+		set -ex ;\
+		[[ -f $(CRDOC) ]] && exit 0 ;\
+		GOBIN=$(TOOLS_DIR) go install fybrik.io/crdoc@$(CRDOC_VERSION) ;\
+	}
+
+.PHONY: jsonnet
+$(JSONNET) jsonnet: $(TOOLS_DIR)
+		GOBIN=$(TOOLS_DIR) go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+
+.PHONY: jsonnetfmt
+$(JSONNETFMT) jsonnetfmt: $(TOOLS_DIR)
+		GOBIN=$(TOOLS_DIR)  go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+
+.PHONY: jsonnet-lint
+$(JSONNET_LINT) jsonnet-lint: $(TOOLS_DIR)
+	GOBIN=$(TOOLS_DIR)  go install github.com/google/go-jsonnet/cmd/jsonnet-lint@latest
+
+.PHONY: jb
+$(JB) jb: $(TOOLS_DIR)
+	GOBIN=$(TOOLS_DIR) go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+
+.PHONY: gojsontoyaml
+$(GOJSONTOYAML) gojsontoyaml: $(TOOLS_DIR)
+	GOBIN=$(TOOLS_DIR) go install github.com/brancz/gojsontoyaml@latest
+
+.PHONY: jsonnet-tools
+jsonnet-tools: jsonnet jsonnetfmt jsonnet-lint jb gojsontoyaml
+
+# Install all required tools
+.PHONY: tools
+tools: $(CONTROLLER_GEN) \
+ 		$(KUSTOMIZE) \
+		$(OC) \
+		$(OPERATOR_SDK) \
+		$(OPM) \
+	 	$(PROMQ) \
+	 	$(CRDOC) \
+	 	jsonnet-tools
+	@{ \
+		set -ex ;\
+		tools_file=.github/tools ;\
+		echo '# DO NOT EDIT! Autogenerated by make tools' > $$tools_file ;\
+		echo '' >> $$tools_file ;\
+		echo  $$(basename $(CONTROLLER_GEN)) $(CONTROLLER_GEN_VERSION) >> $$tools_file ;\
+		echo  $$(basename $(KUSTOMIZE)) $(KUSTOMIZE_VERSION) >> $$tools_file ;\
+		echo  $$(basename $(OC)) $(OC_VERSION) >> $$tools_file ;\
+		echo  $$(basename $(OPERATOR_SDK)) $(OPERATOR_SDK_VERSION) >> $$tools_file ;\
+		echo  $$(basename $(OPM)) $(OPM_VERSION) >> $$tools_file ;\
+		echo  $$(basename $(PROMQ)) $(PROMQ_VERSION) >> $$tools_file ;\
+		echo  $$(basename $(CRDOC)) $(CRDOC_VERSION) >> $$tools_file ; \
+		echo  $$(basename $(JSONNET)) $(JSONNET_VERSION) >> $$tools_file ;\
+		echo  $$(basename $(JSONNETFMT)) $(JSONNETFMT_VERSION) >> $$tools_file ;\
+		echo  $$(basename $(JSONNET_LINT)) $(JSONNET_LINT_VERSION) >> $$tools_file ;\
+		echo  $$(basename $(JB)) $(JB_VERSION) >> $$tools_file ;\
+		echo  $$(basename $(GOJSONTOYAML)) $(GOJSONTOYAML_VERSRION) >> $$tools_file ;\
+	}
+
+.PHONY: validate-tools
+validate-tools:
+	@$(CONTROLLER_GEN) --version
+	@$(KUSTOMIZE) version
+	@$(OC) version --client
+	@$(OPERATOR_SDK) version
+	@$(OPM) version
+	@$(PROMQ) --help | head -n 2
+	@$(CRDOC) --help | head -n 3
+	@$(JSONNETFMT) --version
+	@$(JSONNET_LINT) --version
+	@$(JB) --version

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,436 @@
+# API Reference
+
+Packages:
+
+- [monitoring.rhobs/v1alpha1](#monitoringrhobsv1alpha1)
+
+# monitoring.rhobs/v1alpha1
+
+Resource Types:
+
+- [MonitoringStack](#monitoringstack)
+
+- [ThanosQuerier](#thanosquerier)
+
+
+
+
+## MonitoringStack
+<sup><sup>[↩ Parent](#monitoringrhobsv1alpha1 )</sup></sup>
+
+
+
+
+
+
+MonitoringStack is the Schema for the monitoringstacks API
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+      <td><b>apiVersion</b></td>
+      <td>string</td>
+      <td>monitoring.rhobs/v1alpha1</td>
+      <td>true</td>
+      </tr>
+      <tr>
+      <td><b>kind</b></td>
+      <td>string</td>
+      <td>MonitoringStack</td>
+      <td>true</td>
+      </tr>
+      <tr>
+      <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">metadata</a></b></td>
+      <td>object</td>
+      <td>Refer to the Kubernetes API documentation for the fields of the `metadata` field.</td>
+      <td>true</td>
+      </tr><tr>
+        <td><b><a href="#monitoringstackspec">spec</a></b></td>
+        <td>object</td>
+        <td>
+          MonitoringStackSpec is the specification for desired Monitoring Stack<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>status</b></td>
+        <td>object</td>
+        <td>
+          MonitoringStackStatus defines the observed state of MonitoringStack. It should always be reconstructable from the state of the cluster and/or outside world.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### MonitoringStack.spec
+<sup><sup>[↩ Parent](#monitoringstack)</sup></sup>
+
+
+
+MonitoringStackSpec is the specification for desired Monitoring Stack
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>logLevel</b></td>
+        <td>enum</td>
+        <td>
+          Loglevel set log levels of configured components<br/>
+          <br/>
+            <i>Enum</i>: debug, info, warning<br/>
+            <i>Default</i>: info<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#monitoringstackspecresourceselector">resourceSelector</a></b></td>
+        <td>object</td>
+        <td>
+          Label selector for Monitoring Stack Resources.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#monitoringstackspecresources">resources</a></b></td>
+        <td>object</td>
+        <td>
+          Define resources requests and limits for Monitoring Stack Pods.<br/>
+          <br/>
+            <i>Default</i>: map[limits:map[cpu:500m memory:512M] requests:map[cpu:100m memory:256M]]<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>retention</b></td>
+        <td>string</td>
+        <td>
+          Time duration to retain data for. Default is '120h', and must match the regular expression `[0-9]+(ms|s|m|h|d|w|y)` (milliseconds seconds minutes hours days weeks years).<br/>
+          <br/>
+            <i>Default</i>: 120h<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### MonitoringStack.spec.resourceSelector
+<sup><sup>[↩ Parent](#monitoringstackspec)</sup></sup>
+
+
+
+Label selector for Monitoring Stack Resources.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#monitoringstackspecresourceselectormatchexpressionsindex">matchExpressions</a></b></td>
+        <td>[]object</td>
+        <td>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>matchLabels</b></td>
+        <td>map[string]string</td>
+        <td>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### MonitoringStack.spec.resourceSelector.matchExpressions[index]
+<sup><sup>[↩ Parent](#monitoringstackspecresourceselector)</sup></sup>
+
+
+
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>key</b></td>
+        <td>string</td>
+        <td>
+          key is the label key that the selector applies to.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>operator</b></td>
+        <td>string</td>
+        <td>
+          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### MonitoringStack.spec.resources
+<sup><sup>[↩ Parent](#monitoringstackspec)</sup></sup>
+
+
+
+Define resources requests and limits for Monitoring Stack Pods.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>limits</b></td>
+        <td>map[string]int or string</td>
+        <td>
+          Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>requests</b></td>
+        <td>map[string]int or string</td>
+        <td>
+          Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+## ThanosQuerier
+<sup><sup>[↩ Parent](#monitoringrhobsv1alpha1 )</sup></sup>
+
+
+
+
+
+
+ThanosQuerier outlines the Thanos querier components, managed by this stack
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+      <td><b>apiVersion</b></td>
+      <td>string</td>
+      <td>monitoring.rhobs/v1alpha1</td>
+      <td>true</td>
+      </tr>
+      <tr>
+      <td><b>kind</b></td>
+      <td>string</td>
+      <td>ThanosQuerier</td>
+      <td>true</td>
+      </tr>
+      <tr>
+      <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">metadata</a></b></td>
+      <td>object</td>
+      <td>Refer to the Kubernetes API documentation for the fields of the `metadata` field.</td>
+      <td>true</td>
+      </tr><tr>
+        <td><b><a href="#thanosquerierspec">spec</a></b></td>
+        <td>object</td>
+        <td>
+          ThanosQuerierSpec defines a single Thanos Querier instance. This means a label selector by which Monitoring Stack instances to query are selected, and an optional namespace selector and a list of replica labels by which to deduplicate.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>status</b></td>
+        <td>object</td>
+        <td>
+          ThanosQuerierStatus defines the observed state of ThanosQuerier. It should always be reconstructable from the state of the cluster and/or outside world.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### ThanosQuerier.spec
+<sup><sup>[↩ Parent](#thanosquerier)</sup></sup>
+
+
+
+ThanosQuerierSpec defines a single Thanos Querier instance. This means a label selector by which Monitoring Stack instances to query are selected, and an optional namespace selector and a list of replica labels by which to deduplicate.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#thanosquerierspecselector">selector</a></b></td>
+        <td>object</td>
+        <td>
+          Selector to select Monitoring stacks to unify<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b><a href="#thanosquerierspecnamespaceselector">namespaceSelector</a></b></td>
+        <td>object</td>
+        <td>
+          Selector to select which namespaces the Monitoring Stack objects are discovered from.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>replicaLabels</b></td>
+        <td>[]string</td>
+        <td>
+          <br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### ThanosQuerier.spec.selector
+<sup><sup>[↩ Parent](#thanosquerierspec)</sup></sup>
+
+
+
+Selector to select Monitoring stacks to unify
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#thanosquerierspecselectormatchexpressionsindex">matchExpressions</a></b></td>
+        <td>[]object</td>
+        <td>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>matchLabels</b></td>
+        <td>map[string]string</td>
+        <td>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### ThanosQuerier.spec.selector.matchExpressions[index]
+<sup><sup>[↩ Parent](#thanosquerierspecselector)</sup></sup>
+
+
+
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>key</b></td>
+        <td>string</td>
+        <td>
+          key is the label key that the selector applies to.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>operator</b></td>
+        <td>string</td>
+        <td>
+          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### ThanosQuerier.spec.namespaceSelector
+<sup><sup>[↩ Parent](#thanosquerierspec)</sup></sup>
+
+
+
+Selector to select which namespaces the Monitoring Stack objects are discovered from.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>any</b></td>
+        <td>boolean</td>
+        <td>
+          Boolean describing whether all namespaces are selected in contrast to a list restricting them.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>matchNames</b></td>
+        <td>[]string</td>
+        <td>
+          List of namespace names.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>


### PR DESCRIPTION
Here is how the docs generated by this tool look like: https://github.com/fpetkovski/monitoring-stack-operator/blob/crd-docs/docs/api.md

The only downside of the tool is that it's not able to link to external resources because it relies to yaml files instead of go structs.

We can look into an alternative solution if this one's too verbose.