### PR TITLE
feat: deploy alertmanagers on different nodes

### DIFF
--- a/.github/e2e-tests-olm/action.yaml
+++ b/.github/e2e-tests-olm/action.yaml
@@ -150,6 +150,7 @@ runs:
         # Capture apiserver state
         oc adm inspect node --dest-dir cluster-state || true
         oc adm inspect -A statefulset --dest-dir cluster-state || true
+        oc adm inspect -A deployment --dest-dir cluster-state || true
         oc adm inspect -A ns --dest-dir cluster-state || true
 
     - name: Archive production artifacts

--- a/hack/kind/config.yaml
+++ b/hack/kind/config.yaml
@@ -38,3 +38,5 @@ nodes:
       - hostPath: ./hack/kind/audit-policy.yaml
         containerPath: /etc/kubernetes/policies/audit-policy.yaml
         readOnly: true
+  - role: worker
+  - role: worker


### PR DESCRIPTION
This commit ensures that Alertmanager instances are deployed on
different nodes. It also reduces the number of instances to 2 to make
sure we don't have unnecessary resource usage.