### PR TITLE
docs: change to kubectl create for creating crds

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ to the controller-gen CLI page in the [kubebuilder documentation](https://book.k
 
 * Create a local kubernetes cluster with `kind create cluster`.
 
-* Apply the CRDs by running `kubectl apply -k deploy/crds/kubernetes`
+* Apply the CRDs by running `kubectl create -k deploy/crds/kubernetes`
   * Install OLM locally by running
 
     ```sh


### PR DESCRIPTION
kubectl apply error out when crds have large annotations as in prometheus crd

`The CustomResourceDefinition "prometheuses.monitoring.coreos.com" is invalid: metadata.annotations: Too long: must have at most 262144 bytes`

This issue is there after upgrading prometheus to 0.52.1. We can either overcome it by `kubectl create` or by adding flag `--server-side` in `kubectl apply`, I am updating to create for simplicity

Signed-off-by: Jayapriya Pai <janantha@redhat.com>