### PR TITLE
feat: add a pod disruption budget for Alertmanager

### DIFF
--- a/deploy/operator/monitoring-stack-operator-cluster-role.yaml
+++ b/deploy/operator/monitoring-stack-operator-cluster-role.yaml
@@ -90,6 +90,15 @@ rules:
   - get
   - update
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - list
+  - update
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/pkg/controllers/monitoring-stack/controller.go
+++ b/pkg/controllers/monitoring-stack/controller.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"time"
 
+	policyv1 "k8s.io/api/policy/v1"
+
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	v1 "k8s.io/api/core/v1"
@@ -61,6 +63,7 @@ type Options struct {
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=alertmanagers;prometheuses;servicemonitors,verbs=list;watch;create;update;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=list;watch;create;update;delete
 //+kubebuilder:rbac:groups="",resources=serviceaccounts;services;secrets,verbs=list;watch;create;update;delete
+//+kubebuilder:rbac:groups="policy",resources=poddisruptionbudgets,verbs=list;watch;create;update
 
 // RBAC for managing Grafana CRs
 //+kubebuilder:rbac:groups=integreatly.org,namespace=monitoring-stack-operator,resources=grafanadatasources,verbs=list;watch;create;update;delete
@@ -96,6 +99,7 @@ func RegisterWithManager(mgr ctrl.Manager, opts Options) error {
 		Owns(&rbacv1.Role{}).WithEventFilter(p).
 		Owns(&rbacv1.RoleBinding{}).WithEventFilter(p).
 		Owns(&monv1.ServiceMonitor{}).WithEventFilter(p).
+		Owns(&policyv1.PodDisruptionBudget{}).WithEventFilter(p).
 		Complete(r)
 }
 


### PR DESCRIPTION
This commit adds a Pod Disruption Budget for the Alertmanagers backing
single monitoring stack. The commit also adds a test to make sure all
alertmanagers cannot be evicted at once.