### PR TITLE
feat: upgrade grafana-operator to 4.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,4 +300,6 @@ kind-cluster: $(OPERATOR_SDK)
 	kind create cluster --config hack/kind/config.yaml
 	$(OPERATOR_SDK) olm install
 	kubectl apply -f hack/kind/registry.yaml -n operators
+	kubectl create -k deploy/crds/kubernetes/
+	kubectl create -k deploy/dependencies
 

--- a/pkg/controllers/grafana-operator/filters.go
+++ b/pkg/controllers/grafana-operator/filters.go
@@ -1,0 +1,27 @@
+package grafana_operator
+
+import (
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// installPlanFilter filter events on v1alpha1.InstallPlan resources
+type installPlanFilter struct {
+	predicate.Funcs
+}
+
+// Update returns true only when the v1alpha1.Status.BundleLookup field
+// is set by OLM.
+func (f installPlanFilter) Update(e event.UpdateEvent) bool {
+	previous, ok := e.ObjectOld.(*v1alpha1.InstallPlan)
+	if !ok {
+		return false
+	}
+	current, ok := e.ObjectNew.(*v1alpha1.InstallPlan)
+	if !ok {
+		return false
+	}
+
+	return len(previous.Status.BundleLookups) == 0 && len(current.Status.BundleLookups) != 0
+}


### PR DESCRIPTION
This commit upgrades the Grafana Operator to 4.1.0 and configures the
operator to scan dashboards from all namespace. This change was
introduced in 4.0.2 [1].

https://github.com/grafana-operator/grafana-operator/pull/579