### PR TITLE
fix: establish a watch on Grafana CRs ince the CRD is present

### DIFF
--- a/deploy/operator/monitoring-stack-operator-cluster-role.yaml
+++ b/deploy/operator/monitoring-stack-operator-cluster-role.yaml
@@ -22,13 +22,6 @@ rules:
   - namespaces
   verbs:
   - create
-- apiGroups:
-  - ""
-  resourceNames:
-  - monitoring-stack-operator
-  resources:
-  - namespaces
-  verbs:
   - list
   - watch
 - apiGroups:
@@ -50,6 +43,13 @@ rules:
   - ingresses
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - integreatly.org
+  resources:
+  - grafanas
+  verbs:
   - list
   - watch
 - apiGroups:
@@ -89,6 +89,21 @@ rules:
   verbs:
   - get
   - update
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - installplans
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - operatorgroups
+  - subscriptions
+  verbs:
+  - list
+  - watch
 - apiGroups:
   - policy
   resources:
@@ -134,17 +149,13 @@ rules:
   - grafanas
   verbs:
   - create
-  - list
   - update
-  - watch
 - apiGroups:
   - operators.coreos.com
   resources:
   - installplans
   verbs:
-  - list
   - update
-  - watch
 - apiGroups:
   - operators.coreos.com
   resources:
@@ -152,6 +163,4 @@ rules:
   - subscriptions
   verbs:
   - create
-  - list
   - update
-  - watch


### PR DESCRIPTION
We currently start an informer on Grafana CRs as soon as the operator
starts. This is problematic during installations because the Grafana CRD
will only become available once the grafana operator is installed. As a
result, we quite often get flakes in the CI related to deletion and
restoring of Grafana related resources.

This commit modifies the behavior of the Grafana Operator controller to
establish a watch only when the CRDs have been installed in the cluster.
It also creates watches on all Grafana related resources in order to resolve 
the flakes happening in the CI.