### PR TITLE
fix: correct the naming for mso rule file

### DIFF
--- a/deploy/operator/monitoring-stack-operator-rules.yaml
+++ b/deploy/operator/monitoring-stack-operator-rules.yaml
@@ -3,11 +3,11 @@ kind: PrometheusRule
 metadata:
   labels:
     app.kubernetes.io/component: operator
-    app.kubernetes.io/name: monitoring-stack-operator
+    app.kubernetes.io/name: monitoring-stack-operator-rules
     app.kubernetes.io/part-of: monitoring-stack-operator
     prometheus: k8s
     role: alert-rules
-  name: monitoring-stack-operator-prometheus-rules
+  name: monitoring-stack-operator-rules
 spec:
   groups:
   - name: monitoring-stack-operator.rules


### PR DESCRIPTION
This is a small change to update the label and name for monitoring-stack-operator rule file