### PR TITLE
fix: cleaning up grafana datasource on deleting monitoring stack

### DIFF
--- a/pkg/controllers/monitoring-stack/components.go
+++ b/pkg/controllers/monitoring-stack/components.go
@@ -6,7 +6,7 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 
 	stack "github.com/rhobs/monitoring-stack-operator/pkg/apis/v1alpha1"
-	grafana_operator "github.com/rhobs/monitoring-stack-operator/pkg/controllers/grafana-operator"
+	goctrl "github.com/rhobs/monitoring-stack-operator/pkg/controllers/grafana-operator"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -316,7 +316,7 @@ func stackComponentPatchers(ms *stack.MonitoringStack, instanceSelectorKey strin
 }
 
 func newGrafanaDataSource(ms *stack.MonitoringStack) *grafanav1alpha1.GrafanaDataSource {
-	datasourceName := fmt.Sprintf("ms-%s-%s", ms.Namespace, ms.Name)
+	datasourceName := GrafanaDSName(ms)
 	prometheusURL := fmt.Sprintf("%s-prometheus.%s:9090", ms.Name, ms.Namespace)
 	annotations := map[string]string{
 		grafanaDatasourceOwnerName:      ms.Name,
@@ -331,7 +331,7 @@ func newGrafanaDataSource(ms *stack.MonitoringStack) *grafanav1alpha1.GrafanaDat
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        datasourceName,
-			Namespace:   grafana_operator.Namespace,
+			Namespace:   goctrl.Namespace,
 			Annotations: annotations,
 		},
 		Spec: grafanav1alpha1.GrafanaDataSourceSpec{

--- a/test/e2e/framework/assertions.go
+++ b/test/e2e/framework/assertions.go
@@ -54,14 +54,14 @@ func (f *Framework) AssertResourceNeverExists(name, namespace string, resource c
 				return false, nil
 			}
 
-			return true, fmt.Errorf("statefulset %s/%s should not have been created", namespace, name)
+			return true, fmt.Errorf("resource %s/%s should not have been created", namespace, name)
 		}); err != wait.ErrWaitTimeout {
 			t.Fatal(err)
 		}
 	}
 }
 
-// AssertResourceEventuallyExists asserts that a statefulset is created duration a time period of wait.ForeverTestTimeout
+// AssertResourceEventuallyExists asserts that a resource is created duration a time period of wait.ForeverTestTimeout
 func (f *Framework) AssertResourceEventuallyExists(name, namespace string, resource client.Object, fns ...OptionFn) func(t *testing.T) {
 	option := AssertOption{
 		PollInterval: 5 * time.Second,


### PR DESCRIPTION
this fix will clean up the grafana data source created by the monitoring
stack on deleting the monitoring stack