### PR TITLE
fix: optimise watches used in grafana operator

### DIFF
--- a/deploy/operator/monitoring-stack-operator-cluster-role.yaml
+++ b/deploy/operator/monitoring-stack-operator-cluster-role.yaml
@@ -46,13 +46,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - integreatly.org
-  resources:
-  - grafanas
-  verbs:
-  - list
-  - watch
-- apiGroups:
   - monitoring.coreos.com
   resources:
   - alertmanagers
@@ -89,21 +82,6 @@ rules:
   verbs:
   - get
   - update
-- apiGroups:
-  - operators.coreos.com
-  resources:
-  - installplans
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - operators.coreos.com
-  resources:
-  - operatorgroups
-  - subscriptions
-  verbs:
-  - list
-  - watch
 - apiGroups:
   - policy
   resources:
@@ -149,13 +127,17 @@ rules:
   - grafanas
   verbs:
   - create
+  - list
   - update
+  - watch
 - apiGroups:
   - operators.coreos.com
   resources:
   - installplans
   verbs:
+  - list
   - update
+  - watch
 - apiGroups:
   - operators.coreos.com
   resources:
@@ -163,4 +145,6 @@ rules:
   - subscriptions
   verbs:
   - create
+  - list
   - update
+  - watch


### PR DESCRIPTION
Previously grafana-operator used `source.Kind` to watch the
resources which was far less efficient than the singleResourceInformer.

This patch makes use of `source.NewKindWithCache` which allows building
a cache/informers that watches only the `monitoring-stack-operator`
namespace and only those resources that has the label
`app.kubernetes.io/managed-by=monitoring-stack-operator`

NOTE: `msoClient` is created to make use of the cache.

Signed-off-by: Sunil Thaha <sthaha@redhat.com>
