### PR TITLE
Clean up thanos controller

### DIFF
--- a/deploy/operator/monitoring-stack-operator-cluster-role.yaml
+++ b/deploy/operator/monitoring-stack-operator-cluster-role.yaml
@@ -48,14 +48,9 @@ rules:
   - update
   - watch
 - apiGroups:
-  - apps
-  resources:
-  - deployments/status
-  verbs:
-  - get
-- apiGroups:
   - ""
   resources:
+  - serviceaccounts
   - services
   verbs:
   - create
@@ -64,12 +59,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - services/status
-  verbs:
-  - get
 - apiGroups:
   - extensions
   - networking.k8s.io
@@ -89,6 +78,17 @@ rules:
   - create
   - delete
   - list
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - list
+  - patch
   - update
   - watch
 - apiGroups:
@@ -123,7 +123,6 @@ rules:
   verbs:
   - create
   - delete
-  - get
   - list
   - patch
   - update

--- a/hack/kind/config.yaml
+++ b/hack/kind/config.yaml
@@ -13,7 +13,6 @@ nodes:
       # operator metrics endpoint for scrapping with promq
       - containerPort: 30001
         hostPort: 30001
-    image: kindest/node:v1.22.4
     kubeadmConfigPatches:
       - |
         kind: ClusterConfiguration

--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -100,6 +100,25 @@ type ThanosQuerier struct {
 	Status ThanosQuerierStatus `json:"status,omitempty"`
 }
 
+func (t ThanosQuerier) MatchesNamespace(namespace string) bool {
+	namespaceSelector := t.Spec.NamespaceSelector
+	if namespaceSelector.Any {
+		return true
+	}
+
+	if len(namespaceSelector.MatchNames) == 0 {
+		return t.Namespace == namespace
+	}
+
+	for _, ns := range namespaceSelector.MatchNames {
+		if ns == namespace {
+			return true
+		}
+	}
+
+	return false
+}
+
 // ThanosQuerierList contains a list of ThanosQuerier
 // +kubebuilder:resource
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controllers/thanos-querier/components.go
+++ b/pkg/controllers/thanos-querier/components.go
@@ -16,18 +16,11 @@ type components []client.Object
 
 func thanosComponents(thanos *msoapi.ThanosQuerier, sidecarUrls []string) components {
 	name := "thanos-querier-" + thanos.Name
-	resourceLabels := map[string]string{
-		"app.kubernetes.io/part-of": name,
-	}
-
 	return []client.Object{
-		// ServiceAccount
-		ensureLabels(newServiceAccount(name, thanos.Namespace), resourceLabels),
-		// Deployment
-		ensureLabels(newThanosQuerierDeployment(name, thanos, sidecarUrls), resourceLabels),
-		// Service
-		ensureLabels(newService(name, thanos.Namespace), resourceLabels),
-		ensureLabels(newServiceMonitor(name, thanos.Namespace), resourceLabels),
+		newServiceAccount(name, thanos.Namespace),
+		newThanosQuerierDeployment(name, thanos, sidecarUrls),
+		newService(name, thanos.Namespace),
+		newServiceMonitor(name, thanos.Namespace),
 	}
 }
 

--- a/pkg/controllers/thanos-querier/controller.go
+++ b/pkg/controllers/thanos-querier/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021.
+Copyright 2022.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -14,7 +14,6 @@ package thanos_querier
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -24,12 +23,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -50,24 +46,24 @@ type reconciler struct {
 }
 
 // RBAC for watching monitoring stacks
-//+kubebuilder:rbac:groups=monitoring.rhobs,resources=monitoringstacks,verbs=get;list;watch
+//+kubebuilder:rbac:groups=monitoring.rhobs,resources=monitoringstacks,verbs=list;watch
 
 // RBAC for managing thanosquerier objects
-//+kubebuilder:rbac:groups=monitoring.rhobs,resources=thanosqueriers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=monitoring.rhobs,resources=thanosqueriers,verbs=list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=monitoring.rhobs,resources=thanosqueriers/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=monitoring.rhobs,resources=thanosqueriers/finalizers,verbs=update
 
 // RBAC for managing deployments
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get
 
-// RBAC for managing services
-//+kubebuilder:rbac:groups=core,resources=services,verbs=list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=services/status,verbs=get
+// RBAC for managing core resources
+//+kubebuilder:rbac:groups=core,resources=services;serviceaccounts,verbs=list;watch;create;update;patch;delete
+
+// RBAC for managing Prometheus Operator CRs
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=list;watch;create;update;patch;delete
 
 // RegisterWithManager registers the controller with Manager
 func RegisterWithManager(mgr ctrl.Manager) error {
-
 	logger := ctrl.Log.WithName("thanos-querier")
 	r := &reconciler{
 		Client: mgr.GetClient(),
@@ -82,11 +78,6 @@ func RegisterWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.ServiceAccount{}).WithEventFilter(p).
 		Owns(&corev1.Service{}).WithEventFilter(p).
 		Watches(
-			&source.Kind{Type: &corev1.Service{}},
-			handler.EnqueueRequestsFromMapFunc(r.findQueriersForService),
-			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
-		).
-		Watches(
 			&source.Kind{Type: &msoapi.MonitoringStack{}},
 			handler.EnqueueRequestsFromMapFunc(r.findQueriersForMonitoringStack),
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
@@ -95,44 +86,40 @@ func RegisterWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := r.logger.WithValues("thanosQuerier", req.NamespacedName)
-	logger.Info("Reconciling thanos Querier")
+	logger := r.logger.WithValues("querier", req.NamespacedName)
+	logger.Info("Reconciling Thanos Querier")
 
-	tQuerier, err := r.getQuerierSpec(ctx, req)
-	if err != nil {
-		// retry since some error has occured
-		return ctrl.Result{}, err
-	}
-	if tQuerier == nil {
-		logger.Info("No ThanosQuerier spec found")
+	querier := &msoapi.ThanosQuerier{}
+	err := r.Get(ctx, req.NamespacedName, querier)
+	if apierrors.IsNotFound(err) {
 		return ctrl.Result{}, nil
 	}
-	sidecarServices, err := r.findSidecarServices(ctx, tQuerier)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
+	sidecarServices, err := r.findSidecarServices(ctx, querier)
 	if client.IgnoreNotFound(err) != nil {
 		// we encountered an error other then NotFound, don't try to delete
 		// resources for this querier and reschedule reconcile
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, err
 	}
-	if len(sidecarServices) == 0 {
-		// either no MonitoringStack for this querier exists or it doesn't
-		// expose a thanos-side car service
-		// Clean up any resources that might have been created and return
-		logger.Info("No thanos-sidecar services found, deleting any existing resources")
-		r.maybeDeleteResources(ctx, tQuerier)
-		return ctrl.Result{}, nil
-	}
 
-	components := thanosComponents(tQuerier, sidecarServices)
-
-	controllerLabels := map[string]string{
+	components := thanosComponents(querier, sidecarServices)
+	componentLabels := map[string]string{
+		"app.kubernetes.io/instance":   querier.Name,
+		"app.kubernetes.io/part-of":    "ThanosQuerier",
 		"app.kubernetes.io/managed-by": "monitoring-stack-operator",
 	}
 	for _, c := range components {
-		logger.WithValues("component", c.GetObjectKind().GroupVersionKind())
-		err := r.reconcileComponent(ctx, tQuerier, ensureLabels(c, controllerLabels))
+		err := r.reconcileComponent(ctx, querier, ensureLabels(c, componentLabels))
+		// handle creation / updation errors that can happen due to a stale cache by
+		// retrying after some time.
+		if apierrors.IsAlreadyExists(err) || apierrors.IsConflict(err) {
+			logger.V(8).Info("skipping reconcile error", "err", err)
+			return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+		}
 		if err != nil {
-			logger.Error(err, "Error in reconcile")
 			return ctrl.Result{}, err
 		}
 	}
@@ -150,81 +137,25 @@ func (r reconciler) findSidecarServices(ctx context.Context, tQuerier *msoapi.Th
 		client.MatchingLabelsSelector{Selector: selector},
 	}
 
-	sidecarUrls := []string{}
+	var sidecarUrls []string
 	if err := r.List(ctx, msList, opts...); err != nil {
 		logger.Info("Couldn't find any MonitoringStack")
 		return sidecarUrls, err
 	}
 	logger.Info("Found MonitoringStacks list", "length", len(msList.Items))
 	for _, ms := range msList.Items {
-		svcList := &corev1.ServiceList{}
-		serviceSelector := labels.SelectorFromSet(map[string]string{
-			"app.kubernetes.io/name":    fmt.Sprintf("%s-thanos-sidecar", ms.Name),
-			"app.kubernetes.io/part-of": ms.Name,
-		})
-		opts := []client.ListOption{
-			client.MatchingLabelsSelector{Selector: serviceSelector},
-		}
-		if len(tQuerier.Spec.NamespaceSelector.MatchNames) == 0 {
-			err := r.List(ctx, svcList, opts...)
-			if err != nil {
-				logger.Info("No sidecar services found")
-				return sidecarUrls, err
-			}
-			logger.Info("Found services", "count", len(svcList.Items))
-			sidecarUrls = append(sidecarUrls, getEndpointUrl(svcList)...)
-		} else {
-			for _, ns := range tQuerier.Spec.NamespaceSelector.MatchNames {
-				err := r.List(ctx, svcList, append(opts, client.ListOption(client.InNamespace(ns)))...)
-				if err != nil {
-					logger.Info("No sidecar services found", "namespace", ns)
-					continue
-				}
-				logger.Info("Found services", "namespace", ns, "count", len(svcList.Items))
-				sidecarUrls = append(sidecarUrls, getEndpointUrl(svcList)...)
-			}
+		if tQuerier.MatchesNamespace(ms.Namespace) {
+			serviceName := ms.Name + "-thanos-sidecar"
+			sidecarUrls = append(sidecarUrls, getEndpointUrl(serviceName, ms.Namespace))
 		}
 	}
+
 	return sidecarUrls, nil
 }
 
 // Given a Service object, return a url to use as value for --store/--endpoint.
-func getEndpointUrl(svcList *corev1.ServiceList) []string {
-	var ret []string
-	for _, svc := range svcList.Items {
-		ret = append(ret, fmt.Sprintf("dnssrv+_grpc._tcp.%s.%s.svc.cluster.local", svc.Name, svc.Namespace))
-	}
-	return ret
-}
-
-// Given a reconcile request, get a ThanosQuerier object.
-func (r reconciler) getQuerierSpec(ctx context.Context, req ctrl.Request) (*msoapi.ThanosQuerier, error) {
-	tQuerier := msoapi.ThanosQuerier{}
-
-	err := r.Get(ctx, req.NamespacedName, &tQuerier)
-	return &tQuerier, client.IgnoreNotFound(err)
-}
-
-// For a given Service, retrieve the owning object if it is of Kind
-// MonitoringStack. If such an owner can be found, pass it to
-// findQueriersForMonitoringStack().
-func (r reconciler) findQueriersForService(svc client.Object) []reconcile.Request {
-	logger := r.logger.WithValues("service", svc.GetNamespace()+"/"+svc.GetName())
-	logger.Info("Watched Service changed, checking for matching querier")
-	svcOwners := svc.GetOwnerReferences()
-	logger.Info("Found", "OwnerRefs", svcOwners)
-	err, msName := findMonStackServiceOwner(svcOwners)
-	if err != nil {
-		logger.Info("Owner is not a MonitoringStack, ignoring")
-		return []reconcile.Request{}
-	}
-
-	ms := &msoapi.MonitoringStack{}
-	if err := r.Get(context.Background(), types.NamespacedName{Name: msName, Namespace: svc.GetNamespace()}, ms); err != nil {
-		logger.Info("Failed to get Monitoring Stack for")
-		return []reconcile.Request{}
-	}
-	return r.findQueriersForMonitoringStack(ms)
+func getEndpointUrl(serviceName string, namespace string) string {
+	return fmt.Sprintf("dnssrv+_grpc._tcp.%s.%s.svc.cluster.local", serviceName, namespace)
 }
 
 // Find all ThanosQueriers, whose Selector fits the given MonitoringStack and
@@ -241,7 +172,6 @@ func (r reconciler) findQueriersForMonitoringStack(ms client.Object) []reconcile
 
 	var requests []reconcile.Request
 	for _, item := range queriers.Items {
-
 		sel, err := metav1.LabelSelectorAsSelector(&item.Spec.Selector)
 		if err != nil {
 			return []reconcile.Request{}
@@ -257,19 +187,6 @@ func (r reconciler) findQueriersForMonitoringStack(ms client.Object) []reconcile
 		}
 	}
 	return requests
-}
-
-// Filter a list of OwnerReferences and return the first owner of Kind
-// MonitoringStack.
-func findMonStackServiceOwner(owners []metav1.OwnerReference) (error, string) {
-	for _, owner := range owners {
-		// This should be compared to a MonitoringStack{} object, but in
-		// this case Kind is empty, so use hardcoded string for now
-		if owner.Kind == "MonitoringStack" {
-			return nil, owner.Name
-		}
-	}
-	return errors.New("Owner is not of kind MonitoringStack"), ""
 }
 
 // Create an object after setting the owner reference to the passed
@@ -288,66 +205,15 @@ func (r reconciler) reconcileComponent(ctx context.Context, thanos *msoapi.Thano
 	return nil
 }
 
-// Delete all resources attached to the passed ThanosQuerier, if they still
-// exist.
-func (r reconciler) maybeDeleteResources(ctx context.Context, thanos *msoapi.ThanosQuerier) {
-	logger := r.logger.WithValues("thanosQuerier", thanos.GetNamespace()+"/"+thanos.GetName())
-	logger.Info("Deleting resources created by")
-	for _, gvk := range []schema.GroupVersionKind{
-		{
-			Group:   "apps",
-			Kind:    "Deployment",
-			Version: "v1",
-		},
-		{
-			Group:   "",
-			Kind:    "ServiceAccount",
-			Version: "v1",
-		},
-		{
-			Group:   "monitoring.coreos.com",
-			Kind:    "ServiceMonitor",
-			Version: "v1",
-		},
-	} {
-		resource := &unstructured.Unstructured{}
-		resource.SetGroupVersionKind(gvk)
-		if err := r.DeleteAllOf(ctx, resource, client.InNamespace(thanos.Namespace), client.MatchingLabels{"app.kubernetes.io/part-of": "thanos-querier-" + thanos.Name}); err != nil {
-			if apierrors.IsNotFound(err) {
-				logger.Info("Resources not found, nothing to do")
-			} else {
-				logger.Error(err, "DeleteAllOf failed", "resource", resource)
-			}
-		}
-	}
-	srv := &corev1.Service{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: corev1.SchemeGroupVersion.String(),
-			Kind:       "Service",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "thanos-querier-" + thanos.Name,
-			Namespace: thanos.Namespace,
-		},
-	}
-	if err := r.Delete(ctx, srv); err != nil {
-		if apierrors.IsNotFound(err) {
-			logger.Info("Resources not found, nothing to do")
-		} else {
-			logger.Error(err, "Delete failed", "resource", srv)
-		}
-	}
-}
-
 func ensureLabels(obj client.Object, wantLabels map[string]string) client.Object {
-	labels := obj.GetLabels()
-	if labels == nil {
+	existingLabels := obj.GetLabels()
+	if existingLabels == nil {
 		obj.SetLabels(wantLabels)
 		return obj
 	}
 	for name, val := range wantLabels {
-		if _, ok := labels[name]; !ok {
-			labels[name] = val
+		if _, ok := existingLabels[name]; !ok {
+			existingLabels[name] = val
 		}
 	}
 	return obj

--- a/test/e2e/framework/assertions.go
+++ b/test/e2e/framework/assertions.go
@@ -250,5 +250,6 @@ func (f *Framework) AssertNoReconcileErrors(t *testing.T) {
 		map[string]float64{
 			`{__name__="controller_runtime_reconcile_errors_total", controller="grafana-operator"}`: 0,
 			`{__name__="controller_runtime_reconcile_errors_total", controller="monitoringstack"}`:  0,
+			`{__name__="controller_runtime_reconcile_errors_total", controller="thanosquerier"}`:    0,
 		})
 }


### PR DESCRIPTION
This commit refactors the Thanos Querier controller to remove unused
code and simplify the reconciliation logic.

