### PR TITLE
tools: update golangci-lint to 1.45.2

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42.1
+          version: v1.45.2
           args: --timeout 10m0s
           go-version: ${{ env.go-version }}
 

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -20,7 +20,7 @@ OPM=$(TOOLS_DIR)/opm
 OPM_VERSION = v1.15.1
 
 GOLANGCI_LINT=$(TOOLS_DIR)/golangci-lint
-GOLANGCI_LINT_VERSION = v1.42.1
+GOLANGCI_LINT_VERSION = v1.45.2
 
 ## NOTE: promq does not have any releases, so we use a fake version starting with v0.0.1
 # thus to upgrade/invalidate the github cache, increment the value


### PR DESCRIPTION
Its not entirely clear why 1.42.1 started throwing errors.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>