### PR TITLE
ci: use Makefile for golangci-lint check

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -27,11 +27,8 @@ jobs:
       - name: Import common environment variables
         run: cat ".github/env" >> $GITHUB_ENV
 
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+      - uses: actions/setup-go@v3
         with:
-          version: v1.42.1
-          args: --timeout 10m0s
           go-version: ${{ env.go-version }}
 
       - name: Use go cache
@@ -39,6 +36,9 @@ jobs:
 
       - name: Use tools cache
         uses: ./.github/tools-cache
+
+      - name: golangci-lint
+        run: make lint-golang
 
       - name: jsonnet-fmt
         run: make fmt-jsonnet && git diff --exit-code

--- a/Makefile
+++ b/Makefile
@@ -216,5 +216,5 @@ kind-cluster: $(OPERATOR_SDK)
 	kubectl create -k deploy/dependencies
 
 .PHONY: clean
-clean:
+clean: clean-tools
 	rm -rf $(JSONNET_VENDOR) bundle/ bundle.Dockerfile

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -197,6 +197,10 @@ tools: $(CONTROLLER_GEN) \
 		echo  $$(basename $(GOJSONTOYAML)) $(GOJSONTOYAML_VERSRION) >> $$tools_file ;\
 	}
 
+.PHONY: clean-tools
+clean-tools:
+	rm -rf $(TOOLS_DIR)
+
 .PHONY: validate-tools
 validate-tools:
 	@$(CONTROLLER_GEN) --version

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -20,7 +20,7 @@ OPM=$(TOOLS_DIR)/opm
 OPM_VERSION = v1.15.1
 
 GOLANGCI_LINT=$(TOOLS_DIR)/golangci-lint
-GOLANGCI_LINT_VERSION = v1.42.1
+GOLANGCI_LINT_VERSION = v1.45.2
 
 ## NOTE: promq does not have any releases, so we use a fake version starting with v0.0.1
 # thus to upgrade/invalidate the github cache, increment the value


### PR DESCRIPTION
Without this we potentially run local checks and ghub action check
with two different versions.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>