### PR TITLE
refactor: use server side apply in mso controller

### DIFF
--- a/deploy/operator/monitoring-stack-operator-cluster-role.yaml
+++ b/deploy/operator/monitoring-stack-operator-cluster-role.yaml
@@ -26,6 +26,7 @@ rules:
   - create
   - delete
   - list
+  - patch
   - update
   - watch
 - apiGroups:
@@ -70,6 +71,7 @@ rules:
   - create
   - delete
   - list
+  - patch
   - update
   - watch
 - apiGroups:
@@ -141,6 +143,7 @@ rules:
   - create
   - delete
   - list
+  - patch
   - update
   - watch
 - apiGroups:
@@ -152,5 +155,6 @@ rules:
   - create
   - delete
   - list
+  - patch
   - update
   - watch

--- a/pkg/controllers/monitoring-stack/alertmanager.go
+++ b/pkg/controllers/monitoring-stack/alertmanager.go
@@ -37,10 +37,9 @@ func newAlertmanager(
 			PodMetadata: &monv1.EmbeddedObjectMetadata{
 				Labels: podLabels("alertmanager", ms.Name),
 			},
-			Replicas:                            &replicas,
-			ServiceAccountName:                  rbacResourceName,
-			AlertmanagerConfigSelector:          resourceSelector,
-			AlertmanagerConfigNamespaceSelector: nil,
+			Replicas:                   &replicas,
+			ServiceAccountName:         rbacResourceName,
+			AlertmanagerConfigSelector: resourceSelector,
 			Affinity: &corev1.Affinity{
 				PodAntiAffinity: &corev1.PodAntiAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{


### PR DESCRIPTION
Server side apply has been in beta since kubernetes 1.16 and stable
since 1.22. It greatly reduces client complexity, since no
get-patch-update cycles are needed anymore.
Additionally server side apply allows for controllers to handle user
changes on managed resources much more easily, if that need arises in
the future.
This also adds a `GenerationChangedPredicate` to the GrafanaDataSource watch.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>