### PR TITLE
chore: 3 node kind cluster with comments addressed

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ to the controller-gen CLI page in the [kubebuilder documentation](https://book.k
   ```sh
   kind create cluster --image kindest/node:v1.22.4
   ```
-
+  &nbsp; For more advanced tests, a 3 node cluster may be more suitable.
+  ```sh
+  kind create cluster --config=hack/kind/config.yaml
+  ```
 * Apply the CRDs by running `kubectl create -k deploy/crds/kubernetes`
   * Install OLM locally by running
 

--- a/hack/kind/config.yaml
+++ b/hack/kind/config.yaml
@@ -7,6 +7,7 @@ containerdConfigPatches:
       endpoint = ["http://10.96.223.192:30000"]
 nodes:
   - role: control-plane
+    image: kindest/node:v1.22.4
     extraPortMappings:
       - containerPort: 30000
         hostPort: 30000
@@ -39,4 +40,6 @@ nodes:
         containerPath: /etc/kubernetes/policies/audit-policy.yaml
         readOnly: true
   - role: worker
+    image: kindest/node:v1.22.4
   - role: worker
+    image: kindest/node:v1.22.4


### PR DESCRIPTION
Closes #128

There are certain things that you cannot test on a single node. There are also parts of the application that do not work on a single node (The AlertManager StatefulSet with PodAntiAffinity) 

see #128 for more details.


This feature request is to give the use an alternative kind cluster configuration with the same low barrier to entry. (just copy and paste)

This setup gives the user 3 nodes, for a more production feel than a single node.
```
k get no 
NAME                 STATUS   ROLES                  AGE   VERSION
kind-control-plane   Ready    control-plane,master   50s   v1.22.4
kind-worker          Ready    <none>                 15s   v1.22.4
kind-worker2         Ready    <none>                 15s   v1.22.4
```

The end to end tests **do not break** when you run 3 nodes on the kind cluster. 

Now, you can get all alertmanager pods up from the `sts` and even look at the nodes they are sceduled on:
```
k get po -n tenant-2 -o wide
NAME                      READY   STATUS    RESTARTS   AGE   IP            NODE           NOMINATED NODE   READINESS GATES
alertmanager-tenant-2-0   2/2     Running   0          39s   10.244.1.9    kind-worker    <none>           <none>
alertmanager-tenant-2-1   2/2     Running   0          39s   10.244.2.8    kind-worker2   <none>           <none>
prometheus-tenant-2-0     3/3     Running   0          39s   10.244.1.10   kind-worker    <none>           <none>
```