### PR TITLE
ci: publish versioned catalog images

### DIFF
--- a/.github/olm-publish/action.yaml
+++ b/.github/olm-publish/action.yaml
@@ -51,7 +51,7 @@ runs:
 
   - name: Build Catalog Image
     shell: bash
-    run: make catalog-image FIRST_OLM_RELEASE=false
+    run: make catalog-image
 
   - name: Publish catalog image
     shell: bash

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -147,23 +147,44 @@ $(CRDOC) crdoc: $(TOOLS_DIR)
 
 .PHONY: jsonnet
 $(JSONNET) jsonnet: $(TOOLS_DIR)
-		GOBIN=$(TOOLS_DIR) go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+	@{ \
+		set -ex ;\
+		[[ -f $(JSONNET) ]] && exit 0 ;\
+		GOBIN=$(TOOLS_DIR) go install github.com/google/go-jsonnet/cmd/jsonnet@latest ;\
+	}
+
 
 .PHONY: jsonnetfmt
 $(JSONNETFMT) jsonnetfmt: $(TOOLS_DIR)
-		GOBIN=$(TOOLS_DIR)  go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+	@{ \
+		set -ex ;\
+		[[ -f $(JSONNETFMT) ]] && exit 0 ;\
+		GOBIN=$(TOOLS_DIR)  go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest ;\
+	}
 
 .PHONY: jsonnet-lint
 $(JSONNET_LINT) jsonnet-lint: $(TOOLS_DIR)
-	GOBIN=$(TOOLS_DIR)  go install github.com/google/go-jsonnet/cmd/jsonnet-lint@latest
+	@{ \
+		set -ex ;\
+		[[ -f $(JSONNET_LINT) ]] && exit 0 ;\
+		GOBIN=$(TOOLS_DIR)  go install github.com/google/go-jsonnet/cmd/jsonnet-lint@latest ;\
+	}
 
 .PHONY: jb
 $(JB) jb: $(TOOLS_DIR)
-	GOBIN=$(TOOLS_DIR) go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+	@{ \
+		set -ex ;\
+		[[ -f $(JB) ]] && exit 0 ;\
+		GOBIN=$(TOOLS_DIR) go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest ;\
+	}
 
 .PHONY: gojsontoyaml
 $(GOJSONTOYAML) gojsontoyaml: $(TOOLS_DIR)
-	GOBIN=$(TOOLS_DIR) go install github.com/brancz/gojsontoyaml@latest
+	@{ \
+		set -ex ;\
+		[[ -f $(GOJSONTOYAML) ]] && exit 0 ;\
+		GOBIN=$(TOOLS_DIR) go install github.com/brancz/gojsontoyaml@latest ;\
+	}
 
 .PHONY: jsonnet-tools
 jsonnet-tools: jsonnet jsonnetfmt jsonnet-lint jb gojsontoyaml


### PR DESCRIPTION

Previously, catalog images only used to have :latest image tags. Since
Quay images without tags get garbage collected, it wasn't possible to
pin down a catalog image by its sha256.

This PR, creates a catalog image which has the same version as the
bundle and the operator image. Additionally, it also tags this
versioned image as `latest` so that it is possible to make continuous
deployments (useful for development channel) should the users choose it.

Fixes: https://issues.redhat.com/browse/MON-2498

Signed-off-by: Sunil Thaha <sthaha@redhat.com>
