### PR TITLE
style: switch to human readable time format in logs

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/rhobs/monitoring-stack-operator/pkg/operator"
+	"go.uber.org/zap/zapcore"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -38,6 +39,7 @@ func main() {
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	opts := zap.Options{
 		Development: true,
+		TimeEncoder: zapcore.RFC3339TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
Format log timestamp in the RFC3339. The motivation here is to have human readable time format.
E.g.  The log timestamp is  `1.6523301588633049e+09` is now formatted as `2022-05-13T13:23:10Z`
